### PR TITLE
feat: add get_error_log tool for reading HA logs

### DIFF
--- a/src/tools/error-log.tool.ts
+++ b/src/tools/error-log.tool.ts
@@ -15,10 +15,18 @@ const ErrorLogSchema = z.object({
 
 type ErrorLogParams = z.infer<typeof ErrorLogSchema>;
 
+/**
+ * Strip ANSI escape codes (color sequences) from log output.
+ * The Supervisor logs endpoint returns ANSI-colored text.
+ */
+function stripAnsi(text: string): string {
+  return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
 export const errorLogTool: Tool = {
   name: "get_error_log",
   description:
-    "Get the Home Assistant error log. Useful for troubleshooting integrations, automations, and system issues.",
+    "Get the Home Assistant error log. Useful for troubleshooting integrations, automations, and system issues. Works with both standard HA installations (/api/error_log) and HAOS/Supervisor setups (/api/hassio/core/logs).",
   annotations: {
     title: "Get Error Log",
     readOnlyHint: true,
@@ -30,21 +38,39 @@ export const errorLogTool: Tool = {
   execute: async (params: unknown) => {
     try {
       const { lines, search } = params as ErrorLogParams;
+      const headers = {
+        Authorization: `Bearer ${APP_CONFIG.HASS_TOKEN}`,
+      };
 
-      const response = await fetch(`${APP_CONFIG.HASS_HOST}/api/error_log`, {
-        headers: {
-          Authorization: `Bearer ${APP_CONFIG.HASS_TOKEN}`,
-          "Content-Type": "text/plain",
-        },
+      // Try /api/error_log first (standard HA with file-based logging)
+      let response = await fetch(`${APP_CONFIG.HASS_HOST}/api/error_log`, {
+        headers: { ...headers, "Content-Type": "text/plain" },
       });
+
+      let source = "error_log";
+
+      // Fall back to Supervisor core logs (HAOS / Supervised installs)
+      if (!response.ok) {
+        response = await fetch(
+          `${APP_CONFIG.HASS_HOST}/api/hassio/core/logs`,
+          { headers: { ...headers, Accept: "text/plain" } },
+        );
+        source = "supervisor";
+      }
 
       if (!response.ok) {
         throw new Error(
-          `Failed to fetch error log: ${response.status} ${response.statusText}`,
+          `Failed to fetch error log: ${response.status} ${response.statusText}. ` +
+            "Neither /api/error_log nor /api/hassio/core/logs are available.",
         );
       }
 
       let text = await response.text();
+
+      // Supervisor logs contain ANSI color codes
+      if (source === "supervisor") {
+        text = stripAnsi(text);
+      }
 
       if (search) {
         const needle = search.toLowerCase();
@@ -59,7 +85,7 @@ export const errorLogTool: Tool = {
         text = allLines.slice(-lines).join("\n");
       }
 
-      return JSON.stringify({ success: true, log: text });
+      return JSON.stringify({ success: true, source, log: text });
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : "Unknown error occurred";

--- a/src/tools/error-log.tool.ts
+++ b/src/tools/error-log.tool.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+import { Tool } from "../types/index";
+import { APP_CONFIG } from "../config/app.config";
+
+const ErrorLogSchema = z.object({
+  lines: z
+    .number()
+    .optional()
+    .describe("Number of recent lines to return (default: all)"),
+  search: z
+    .string()
+    .optional()
+    .describe("Filter log lines containing this text (case-insensitive)"),
+});
+
+type ErrorLogParams = z.infer<typeof ErrorLogSchema>;
+
+export const errorLogTool: Tool = {
+  name: "get_error_log",
+  description:
+    "Get the Home Assistant error log. Useful for troubleshooting integrations, automations, and system issues.",
+  annotations: {
+    title: "Get Error Log",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  parameters: ErrorLogSchema,
+  execute: async (params: unknown) => {
+    try {
+      const { lines, search } = params as ErrorLogParams;
+
+      const response = await fetch(`${APP_CONFIG.HASS_HOST}/api/error_log`, {
+        headers: {
+          Authorization: `Bearer ${APP_CONFIG.HASS_TOKEN}`,
+          "Content-Type": "text/plain",
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch error log: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      let text = await response.text();
+
+      if (search) {
+        const needle = search.toLowerCase();
+        text = text
+          .split("\n")
+          .filter((l) => l.toLowerCase().includes(needle))
+          .join("\n");
+      }
+
+      if (lines) {
+        const allLines = text.split("\n");
+        text = allLines.slice(-lines).join("\n");
+      }
+
+      return JSON.stringify({ success: true, log: text });
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Unknown error occurred";
+      return JSON.stringify({ success: false, error: errorMessage });
+    }
+  },
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -34,6 +34,7 @@ import { voiceCommandAIParserTool } from "./homeassistant/voice-command-ai-parse
 import { traceTool } from "./homeassistant/trace.tool";
 import { entityStateTool } from "./entity-state.tool";
 import { searchEntitiesTool } from "./search-entities.tool";
+import { errorLogTool } from "./error-log.tool";
 
 // Tool category types
 export enum ToolCategory {
@@ -98,6 +99,8 @@ export const tools: Tool[] = [
   entityStateTool,
   // Powerful entity search
   searchEntitiesTool,
+  // Error log
+  errorLogTool,
 ];
 
 // Function to get a tool by name
@@ -149,4 +152,6 @@ export {
   entityStateTool,
   // Entity search
   searchEntitiesTool,
+  // Error log
+  errorLogTool,
 };


### PR DESCRIPTION
## Summary

- Adds a new `get_error_log` MCP tool that reads the Home Assistant error log via the `/api/error_log` REST endpoint
- Supports optional `lines` parameter to return only the N most recent lines
- Supports optional `search` parameter for case-insensitive text filtering
- Follows existing tool patterns (annotations, error handling, Zod schema, try/catch with structured JSON responses)

## Motivation

The MCP server has 35+ tools for controlling and querying Home Assistant, but no way to read logs. This makes troubleshooting integrations, automations, and system issues impossible without leaving the AI assistant session.

## Test plan

- [ ] `npm run build` compiles without errors (verified)
- [ ] `tsc --noEmit` shows no new type errors from the added files (verified)
- [ ] Tool follows existing patterns for annotations, error handling, and schema validation
- [ ] Manual test: restart MCP server, call `get_error_log` with no params → returns full log
- [ ] Manual test: call `get_error_log` with `{ "search": "error" }` → returns filtered lines
- [ ] Manual test: call `get_error_log` with `{ "lines": 50 }` → returns last 50 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)