### PR TITLE
Refactor tools with suffix-based behavior naming (_modify / _activate)

### DIFF
--- a/VOICE_COMMAND_QUICK_REF.md
+++ b/VOICE_COMMAND_QUICK_REF.md
@@ -57,7 +57,7 @@ input: {
 ### 2. AI Parser (Optional - requires ANTHROPIC_API_KEY)
 ```python
 # Intelligent, context-aware parsing
-tool: "voice_command_ai_parser"
+tool: "voice_command_ai_parser_activate"
 input: {
   "transcription": "make it warmer",
   "context": {
@@ -72,7 +72,7 @@ input: {
 ### 3. Command Executor
 ```python
 # Execute parsed commands
-tool: "voice_command_executor"
+tool: "voice_command_executor_activate"
 input: {
   "intent": "turn_on",
   "action": "turn_on",
@@ -274,7 +274,7 @@ curl -X POST http://localhost:7123/api/tools/call \
 curl -X POST http://localhost:7123/api/tools/call \
   -H "Content-Type: application/json" \
   -d '{
-    "name": "voice_command_ai_parser",
+    "name": "voice_command_ai_parser_activate",
     "arguments": {
       "transcription": "it is too cold, make it warmer",
       "context": {
@@ -290,7 +290,7 @@ curl -X POST http://localhost:7123/api/tools/call \
 curl -X POST http://localhost:7123/api/tools/call \
   -H "Content-Type: application/json" \
   -d '{
-    "name": "voice_command_executor",
+    "name": "voice_command_executor_activate",
     "arguments": {
       "intent": "set_temperature",
       "action": "set_temperature",

--- a/__tests__/core/server.test.ts
+++ b/__tests__/core/server.test.ts
@@ -12,7 +12,7 @@ describe("Home Assistant MCP Server tool registry", () => {
   test("registers list_devices and control tools", () => {
     const toolNames = indexTools.map((tool: IndexTool) => tool.name);
     expect(toolNames).toContain("list_devices");
-    expect(toolNames).toContain("control");
+    expect(toolNames).toContain("control_activate");
   });
 
   test("list_devices description references devices", () => {
@@ -26,7 +26,7 @@ describe("Home Assistant MCP Server tool registry", () => {
   });
 
   test("control description references devices and services", () => {
-    const controlTool = indexTools.find((tool: IndexTool) => tool.name === "control");
+    const controlTool = indexTools.find((tool: IndexTool) => tool.name === "control_activate");
     expect(controlTool).toBeDefined();
     expect(controlTool?.description).toContain("Control Home Assistant devices and services");
   });

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -59,7 +59,7 @@ describe('Home Assistant MCP Server', () => {
             const toolNames = tools.map(tool => tool.name);
 
             expect(toolNames).toContain('list_devices');
-            expect(toolNames).toContain('control');
+            expect(toolNames).toContain('control_activate');
         });
 
         test('should configure tools with correct parameters', () => {
@@ -67,7 +67,7 @@ describe('Home Assistant MCP Server', () => {
             expect(listDevicesTool).toBeDefined();
             expect(listDevicesTool?.parameters).toBeDefined();
 
-            const controlTool = tools.find(tool => tool.name === 'control');
+            const controlTool = tools.find(tool => tool.name === 'control_activate');
             expect(controlTool).toBeDefined();
             expect(controlTool?.parameters).toBeDefined();
         });
@@ -99,7 +99,7 @@ describe('Home Assistant MCP Server', () => {
         });
 
         test('should execute control tool', async () => {
-            const controlTool = tools.find(tool => tool.name === 'control');
+            const controlTool = tools.find(tool => tool.name === 'control_activate');
             expect(controlTool).toBeDefined();
 
             mockFetch = createMockFetch({ success: true });

--- a/__tests__/tools/all-tools.test.ts
+++ b/__tests__/tools/all-tools.test.ts
@@ -52,40 +52,58 @@ describe("Comprehensive Tool Suite Tests", () => {
         // regressions.
         const expectedTools = [
             "addon",
-            "alarm_control",
+            "addon_modify",
+            "alarms",
+            "alarms_activate",
             "animation_control",
+            "animation_control_activate",
             "automation",
-            "automation_config",
-            "climate_control",
-            "control",
-            "cover_control",
+            "automation_activate",
+            "automation_config_modify",
+            "automation_modify",
+            "climate",
+            "climate_activate",
+            "control_activate",
+            "covers",
+            "covers_activate",
             "dashboard",
-            "fan_control",
+            "dashboard_modify",
+            "fans",
+            "fans_activate",
             "get_entity_state",
             "get_error_log",
             "get_history",
             "get_sse_stats",
-            "light_animation",
-            "light_scenario",
-            "light_showcase",
-            "lights_control",
+            "light_animation_activate",
+            "light_scenario_activate",
+            "light_showcase_activate",
+            "lights",
+            "lights_activate",
             "list_devices",
-            "lock_control",
+            "locks",
+            "locks_activate",
             "maintenance",
-            "media_player_control",
-            "notify",
+            "media_players",
+            "media_players_activate",
+            "notify_activate",
             "package",
+            "package_modify",
             "render_template",
             "scene",
+            "scene_activate",
             "search_entities",
             "smart_scenarios",
+            "smart_scenarios_activate",
             "subscribe_events",
-            "switch_control",
-            "todo_control",
+            "switches",
+            "switches_activate",
+            "todo",
+            "todo_modify",
             "trace",
-            "vacuum_control",
-            "voice_command_ai_parser",
-            "voice_command_executor",
+            "vacuums",
+            "vacuums_activate",
+            "voice_command_ai_parser_activate",
+            "voice_command_executor_activate",
             "voice_command_parser",
         ].sort();
 
@@ -115,6 +133,20 @@ describe("Comprehensive Tool Suite Tests", () => {
             const toolNames = tools.map((t) => t.name).sort();
             expect(toolNames).toEqual(expectedTools);
         });
+
+        test("read-only tools end with no suffix; mutators end with _modify or _activate", () => {
+            for (const tool of tools) {
+                const ro = tool.annotations?.readOnlyHint === true;
+                const isModify = tool.name.endsWith("_modify");
+                const isActivate = tool.name.endsWith("_activate");
+                if (ro) {
+                    expect(isModify).toBe(false);
+                    expect(isActivate).toBe(false);
+                } else {
+                    expect(isModify || isActivate).toBe(true);
+                }
+            }
+        });
     });
 
     describe("Control Tool", () => {
@@ -122,7 +154,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const controlTool = tools.find((t) => t.name === "control");
+            const controlTool = tools.find((t) => t.name === "control_activate");
             expect(controlTool).toBeDefined();
 
             if (!controlTool) throw new Error("control tool not found");
@@ -137,7 +169,7 @@ describe("Comprehensive Tool Suite Tests", () => {
         });
 
         test("should handle missing entity_id and area_id", async () => {
-            const controlTool = tools.find((t) => t.name === "control");
+            const controlTool = tools.find((t) => t.name === "control_activate");
             expect(controlTool).toBeDefined();
 
             if (!controlTool) throw new Error("control tool not found");
@@ -152,7 +184,7 @@ describe("Comprehensive Tool Suite Tests", () => {
         });
 
         test("should reject unsupported domains", async () => {
-            const controlTool = tools.find((t) => t.name === "control");
+            const controlTool = tools.find((t) => t.name === "control_activate");
             expect(controlTool).toBeDefined();
 
             if (!controlTool) throw new Error("control tool not found");
@@ -171,7 +203,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const controlTool = tools.find((t) => t.name === "control");
+            const controlTool = tools.find((t) => t.name === "control_activate");
             expect(controlTool).toBeDefined();
 
             if (!controlTool) throw new Error("control tool not found");
@@ -313,10 +345,10 @@ describe("Comprehensive Tool Suite Tests", () => {
             );
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const addonTool = tools.find((t) => t.name === "addon");
+            const addonTool = tools.find((t) => t.name === "addon_modify");
             expect(addonTool).toBeDefined();
 
-            if (!addonTool) throw new Error("addon tool not found");
+            if (!addonTool) throw new Error("addon_modify tool not found");
 
             const result: unknown = await addonTool.execute({
                 action: "install",
@@ -357,10 +389,10 @@ describe("Comprehensive Tool Suite Tests", () => {
         });
 
         test("should require repository for install action", async () => {
-            const packageTool = tools.find((t) => t.name === "package");
+            const packageTool = tools.find((t) => t.name === "package_modify");
             expect(packageTool).toBeDefined();
 
-            if (!packageTool) throw new Error("package tool not found");
+            if (!packageTool) throw new Error("package_modify tool not found");
 
             const result: unknown = await packageTool.execute({
                 action: "install",
@@ -375,10 +407,10 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const packageTool = tools.find((t) => t.name === "package");
+            const packageTool = tools.find((t) => t.name === "package_modify");
             expect(packageTool).toBeDefined();
 
-            if (!packageTool) throw new Error("package tool not found");
+            if (!packageTool) throw new Error("package_modify tool not found");
 
             const result: unknown = await packageTool.execute({
                 action: "install",
@@ -395,7 +427,7 @@ describe("Comprehensive Tool Suite Tests", () => {
     describe("Automation Config Tool", () => {
         test("should require config for create action", async () => {
             const automationConfigTool = tools.find(
-                (t) => t.name === "automation_config"
+                (t) => t.name === "automation_config_modify"
             );
             expect(automationConfigTool).toBeDefined();
 
@@ -432,7 +464,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
             const automationConfigTool = tools.find(
-                (t) => t.name === "automation_config"
+                (t) => t.name === "automation_config_modify"
             );
             expect(automationConfigTool).toBeDefined();
 
@@ -538,7 +570,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const lightsTool = tools.find((t) => t.name === "lights_control");
+            const lightsTool = tools.find((t) => t.name === "lights_activate");
             expect(lightsTool).toBeDefined();
 
             if (!lightsTool) throw new Error("lights tool not found");
@@ -556,7 +588,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const lightsTool = tools.find((t) => t.name === "lights_control");
+            const lightsTool = tools.find((t) => t.name === "lights_activate");
             expect(lightsTool).toBeDefined();
 
             if (!lightsTool) throw new Error("lights tool not found");
@@ -584,7 +616,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             );
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const lightsTool = tools.find((t) => t.name === "lights_control");
+            const lightsTool = tools.find((t) => t.name === "lights");
             expect(lightsTool).toBeDefined();
 
             if (!lightsTool) throw new Error("lights tool not found");
@@ -599,7 +631,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const lightsTool = tools.find((t) => t.name === "lights_control");
+            const lightsTool = tools.find((t) => t.name === "lights_activate");
             expect(lightsTool).toBeDefined();
 
             if (!lightsTool) throw new Error("lights tool not found");
@@ -620,7 +652,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const climateTool = tools.find((t) => t.name === "climate_control");
+            const climateTool = tools.find((t) => t.name === "climate_activate");
             expect(climateTool).toBeDefined();
 
             if (!climateTool) throw new Error("climate tool not found");
@@ -639,7 +671,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const climateTool = tools.find((t) => t.name === "climate_control");
+            const climateTool = tools.find((t) => t.name === "climate_activate");
             expect(climateTool).toBeDefined();
 
             if (!climateTool) throw new Error("climate tool not found");
@@ -668,7 +700,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             );
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const climateTool = tools.find((t) => t.name === "climate_control");
+            const climateTool = tools.find((t) => t.name === "climate");
             expect(climateTool).toBeDefined();
 
             if (!climateTool) throw new Error("climate tool not found");
@@ -685,7 +717,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const coverTool = tools.find((t) => t.name === "cover_control");
+            const coverTool = tools.find((t) => t.name === "covers_activate");
             expect(coverTool).toBeDefined();
 
             if (!coverTool) throw new Error("cover tool not found");
@@ -703,7 +735,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const coverTool = tools.find((t) => t.name === "cover_control");
+            const coverTool = tools.find((t) => t.name === "covers_activate");
             expect(coverTool).toBeDefined();
 
             if (!coverTool) throw new Error("cover tool not found");
@@ -721,7 +753,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const coverTool = tools.find((t) => t.name === "cover_control");
+            const coverTool = tools.find((t) => t.name === "covers_activate");
             expect(coverTool).toBeDefined();
 
             if (!coverTool) throw new Error("cover tool not found");
@@ -742,7 +774,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const fanTool = tools.find((t) => t.name === "fan_control");
+            const fanTool = tools.find((t) => t.name === "fans_activate");
             expect(fanTool).toBeDefined();
 
             if (!fanTool) throw new Error("fan tool not found");
@@ -760,7 +792,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const fanTool = tools.find((t) => t.name === "fan_control");
+            const fanTool = tools.find((t) => t.name === "fans_activate");
             expect(fanTool).toBeDefined();
 
             if (!fanTool) throw new Error("fan tool not found");
@@ -789,10 +821,10 @@ describe("Comprehensive Tool Suite Tests", () => {
             );
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const fanTool = tools.find((t) => t.name === "fan_control");
+            const fanTool = tools.find((t) => t.name === "fans");
             expect(fanTool).toBeDefined();
 
-            if (!fanTool) throw new Error("fan tool not found");
+            if (!fanTool) throw new Error("fans tool not found");
 
             const result: unknown = await fanTool.execute({ action: "list" });
 
@@ -806,7 +838,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const lockTool = tools.find((t) => t.name === "lock_control");
+            const lockTool = tools.find((t) => t.name === "locks_activate");
             expect(lockTool).toBeDefined();
 
             if (!lockTool) throw new Error("lock tool not found");
@@ -824,7 +856,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const lockTool = tools.find((t) => t.name === "lock_control");
+            const lockTool = tools.find((t) => t.name === "locks_activate");
             expect(lockTool).toBeDefined();
 
             if (!lockTool) throw new Error("lock tool not found");
@@ -853,10 +885,10 @@ describe("Comprehensive Tool Suite Tests", () => {
             );
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const lockTool = tools.find((t) => t.name === "lock_control");
+            const lockTool = tools.find((t) => t.name === "locks");
             expect(lockTool).toBeDefined();
 
-            if (!lockTool) throw new Error("lock tool not found");
+            if (!lockTool) throw new Error("locks tool not found");
 
             const result: unknown = await lockTool.execute({ action: "list" });
 
@@ -870,7 +902,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const vacuumTool = tools.find((t) => t.name === "vacuum_control");
+            const vacuumTool = tools.find((t) => t.name === "vacuums_activate");
             expect(vacuumTool).toBeDefined();
 
             if (!vacuumTool) throw new Error("vacuum tool not found");
@@ -888,7 +920,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const vacuumTool = tools.find((t) => t.name === "vacuum_control");
+            const vacuumTool = tools.find((t) => t.name === "vacuums_activate");
             expect(vacuumTool).toBeDefined();
 
             if (!vacuumTool) throw new Error("vacuum tool not found");
@@ -916,10 +948,10 @@ describe("Comprehensive Tool Suite Tests", () => {
             );
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const vacuumTool = tools.find((t) => t.name === "vacuum_control");
+            const vacuumTool = tools.find((t) => t.name === "vacuums");
             expect(vacuumTool).toBeDefined();
 
-            if (!vacuumTool) throw new Error("vacuum tool not found");
+            if (!vacuumTool) throw new Error("vacuums tool not found");
 
             const result: unknown = await vacuumTool.execute({ action: "list" });
 
@@ -934,7 +966,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
             const mediaPlayerTool = tools.find(
-                (t) => t.name === "media_player_control"
+                (t) => t.name === "media_players_activate"
             );
             expect(mediaPlayerTool).toBeDefined();
 
@@ -955,7 +987,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
             const mediaPlayerTool = tools.find(
-                (t) => t.name === "media_player_control"
+                (t) => t.name === "media_players_activate"
             );
             expect(mediaPlayerTool).toBeDefined();
 
@@ -986,12 +1018,12 @@ describe("Comprehensive Tool Suite Tests", () => {
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
             const mediaPlayerTool = tools.find(
-                (t) => t.name === "media_player_control"
+                (t) => t.name === "media_players"
             );
             expect(mediaPlayerTool).toBeDefined();
 
             if (!mediaPlayerTool)
-                throw new Error("media_player tool not found");
+                throw new Error("media_players tool not found");
 
             const result: unknown = await mediaPlayerTool.execute({ action: "list" });
 
@@ -1005,7 +1037,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const alarmTool = tools.find((t) => t.name === "alarm_control");
+            const alarmTool = tools.find((t) => t.name === "alarms_activate");
             expect(alarmTool).toBeDefined();
 
             if (!alarmTool) throw new Error("alarm_control tool not found");
@@ -1023,7 +1055,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const alarmTool = tools.find((t) => t.name === "alarm_control");
+            const alarmTool = tools.find((t) => t.name === "alarms_activate");
             expect(alarmTool).toBeDefined();
 
             if (!alarmTool) throw new Error("alarm_control tool not found");
@@ -1052,10 +1084,10 @@ describe("Comprehensive Tool Suite Tests", () => {
             );
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const alarmTool = tools.find((t) => t.name === "alarm_control");
+            const alarmTool = tools.find((t) => t.name === "alarms");
             expect(alarmTool).toBeDefined();
 
-            if (!alarmTool) throw new Error("alarm_control tool not found");
+            if (!alarmTool) throw new Error("alarms tool not found");
 
             const result: unknown = await alarmTool.execute({ action: "list" });
 
@@ -1094,13 +1126,12 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const automationTool = tools.find((t) => t.name === "automation");
+            const automationTool = tools.find((t) => t.name === "automation_modify");
             expect(automationTool).toBeDefined();
 
-            if (!automationTool) throw new Error("automation tool not found");
+            if (!automationTool) throw new Error("automation_modify tool not found");
 
             const result: unknown = await automationTool.execute({
-                action: "toggle",
                 automation_id: "automation.test",
             });
 
@@ -1139,10 +1170,10 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const sceneTool = tools.find((t) => t.name === "scene");
+            const sceneTool = tools.find((t) => t.name === "scene_activate");
             expect(sceneTool).toBeDefined();
 
-            if (!sceneTool) throw new Error("scene tool not found");
+            if (!sceneTool) throw new Error("scene_activate tool not found");
 
             const result: unknown = await sceneTool.execute({
                 action: "activate",
@@ -1159,7 +1190,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const notifyTool = tools.find((t) => t.name === "notify");
+            const notifyTool = tools.find((t) => t.name === "notify_activate");
             expect(notifyTool).toBeDefined();
 
             if (!notifyTool) throw new Error("notify tool not found");
@@ -1177,7 +1208,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             mocks.mockFetch = mock(() => Promise.resolve(createMockResponse({})));
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
-            const notifyTool = tools.find((t) => t.name === "notify");
+            const notifyTool = tools.find((t) => t.name === "notify_activate");
             expect(notifyTool).toBeDefined();
 
             if (!notifyTool) throw new Error("notify tool not found");
@@ -1249,7 +1280,7 @@ describe("Comprehensive Tool Suite Tests", () => {
             globalThis.fetch = mocks.mockFetch as unknown as typeof fetch;
 
             // Test a few tools for error handling
-            const controlTool = tools.find((t) => t.name === "control");
+            const controlTool = tools.find((t) => t.name === "control_activate");
             if (!controlTool) throw new Error("control tool not found");
 
             const result: unknown = await controlTool.execute({

--- a/__tests__/tools/automation-config.test.ts
+++ b/__tests__/tools/automation-config.test.ts
@@ -12,7 +12,7 @@ interface ParsedTextPayload {
   automation_id?: string;
 }
 
-const automationConfigTool = tools.find((t) => t.name === "automation_config")!;
+const automationConfigTool = tools.find((t) => t.name === "automation_config_modify")!;
 
 // The automation_config tool returns FastMCP-style `{content: [{type, text}]}`,
 // where `text` is a JSON-encoded payload. This helper handles both the FastMCP
@@ -26,7 +26,7 @@ function extractPayload(result: unknown): ParsedTextPayload {
   return result as ParsedTextPayload;
 }
 
-describe("automation_config tool", () => {
+describe("automation_config_modify tool", () => {
   beforeEach(() => {
     globalThis.fetch = mock(() =>
       Promise.resolve(createMockResponse({})),
@@ -35,7 +35,7 @@ describe("automation_config tool", () => {
 
   test("the tool is registered", () => {
     expect(automationConfigTool).toBeDefined();
-    expect(automationConfigTool.name).toBe("automation_config");
+    expect(automationConfigTool.name).toBe("automation_config_modify");
   });
 
   test("create requires a config object", async () => {

--- a/__tests__/tools/automation.test.ts
+++ b/__tests__/tools/automation.test.ts
@@ -13,12 +13,14 @@ interface AutomationResult {
 }
 
 const automationTool = tools.find((t) => t.name === "automation")!;
+const automationModifyTool = tools.find((t) => t.name === "automation_modify")!;
+const automationActivateTool = tools.find((t) => t.name === "automation_activate")!;
 
 function parseResult(result: unknown): AutomationResult {
   return JSON.parse(result as string) as AutomationResult;
 }
 
-describe("automation tool", () => {
+describe("automation tool (read-only)", () => {
   beforeEach(async () => {
     // Default fetch mock just returns an empty success body. Individual tests
     // override `globalThis.fetch` for the call shapes they actually exercise.
@@ -57,14 +59,21 @@ describe("automation tool", () => {
     expect(result.automations?.[0]?.entity_id).toBe("automation.morning_lights");
     expect(result.automations?.[0]?.name).toBe("Morning lights");
   });
+});
+
+describe("automation_modify tool (toggle)", () => {
+  beforeEach(() => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(createMockResponse({})),
+    ) as unknown as typeof fetch;
+  });
 
   test("toggle calls the automation/toggle service for the given entity", async () => {
     const fetchMock = mock(() => Promise.resolve(createMockResponse({})));
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
     const result = parseResult(
-      await automationTool.execute({
-        action: "toggle",
+      await automationModifyTool.execute({
         automation_id: "automation.morning_lights",
       }),
     );
@@ -81,13 +90,25 @@ describe("automation tool", () => {
     expect(JSON.parse(init.body as string)).toEqual({ entity_id: "automation.morning_lights" });
   });
 
+  test("schema requires automation_id (enforced at the transport layer by Zod)", () => {
+    const shape = (automationModifyTool.parameters as { shape?: Record<string, unknown> }).shape;
+    expect(shape?.automation_id).toBeDefined();
+  });
+});
+
+describe("automation_activate tool (trigger)", () => {
+  beforeEach(() => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(createMockResponse({})),
+    ) as unknown as typeof fetch;
+  });
+
   test("trigger calls the automation/trigger service for the given entity", async () => {
     const fetchMock = mock(() => Promise.resolve(createMockResponse({})));
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
     const result = parseResult(
-      await automationTool.execute({
-        action: "trigger",
+      await automationActivateTool.execute({
         automation_id: "automation.morning_lights",
       }),
     );
@@ -99,9 +120,8 @@ describe("automation tool", () => {
     );
   });
 
-  test("toggle/trigger without automation_id returns success:false with a clear message", async () => {
-    const result = parseResult(await automationTool.execute({ action: "toggle" }));
-    expect(result.success).toBe(false);
-    expect(result.message).toContain("Automation ID is required");
+  test("schema requires automation_id (enforced at the transport layer by Zod)", () => {
+    const shape = (automationActivateTool.parameters as { shape?: Record<string, unknown> }).shape;
+    expect(shape?.automation_id).toBeDefined();
   });
 });

--- a/__tests__/tools/scene-control.test.ts
+++ b/__tests__/tools/scene-control.test.ts
@@ -17,8 +17,9 @@ interface SceneActivateResult {
 }
 
 const sceneTool = tools.find((t) => t.name === "scene")!;
+const sceneActivateTool = tools.find((t) => t.name === "scene_activate")!;
 
-describe("scene tool", () => {
+describe("scene tool (read-only list)", () => {
   beforeEach(async () => {
     globalThis.fetch = mock(() =>
       Promise.resolve(createMockResponse({})),
@@ -56,12 +57,25 @@ describe("scene tool", () => {
     expect(result.scenes?.[0]?.entity_id).toBe("scene.movie_night");
     expect(result.scenes?.[0]?.name).toBe("Movie night");
   });
+});
+
+describe("scene_activate tool", () => {
+  beforeEach(() => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(createMockResponse({})),
+    ) as unknown as typeof fetch;
+  });
+
+  test("the tool is registered", () => {
+    expect(sceneActivateTool).toBeDefined();
+    expect(sceneActivateTool.name).toBe("scene_activate");
+  });
 
   test("activate calls scene.turn_on with the scene entity_id", async () => {
     const fetchMock = mock(() => Promise.resolve(createMockResponse({})));
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-    const raw = await sceneTool.execute({
+    const raw = await sceneActivateTool.execute({
       action: "activate",
       scene_id: "scene.movie_night",
     });
@@ -76,10 +90,8 @@ describe("scene tool", () => {
     expect(JSON.parse(init.body as string)).toEqual({ entity_id: "scene.movie_night" });
   });
 
-  test("activate without scene_id surfaces success:false", async () => {
-    const raw = await sceneTool.execute({ action: "activate" });
-    const result = JSON.parse(raw as string) as SceneActivateResult;
-    expect(result.success).toBe(false);
-    expect(result.message?.toLowerCase()).toContain("scene id is required");
+  test("schema requires scene_id (enforced at the transport layer by Zod)", () => {
+    const shape = (sceneActivateTool.parameters as { shape?: Record<string, unknown> }).shape;
+    expect(shape?.scene_id).toBeDefined();
   });
 });

--- a/docs/TOOLS_REFERENCE.md
+++ b/docs/TOOLS_REFERENCE.md
@@ -673,7 +673,7 @@ When using with AI assistants, you can use natural language:
 # Via HTTP
 curl -X POST http://localhost:3000/api/tools/call \
   -H "Content-Type: application/json" \
-  -d '{"tool": "lights_control", "params": {"action": "turn_on", "entity_id": "light.living_room"}}'
+  -d '{"tool": "lights_activate", "params": {"action": "turn_on", "entity_id": "light.living_room"}}'
 
 # Via WebSocket
 ws://localhost:3000/api/ws
@@ -687,7 +687,7 @@ ws://localhost:3000/api/ws
   "id": 1,
   "method": "tools/call",
   "params": {
-    "name": "lights_control",
+    "name": "lights_activate",
     "arguments": {
       "action": "turn_on",
       "entity_id": "light.living_room",

--- a/docs/VOICE_COMMAND_EXECUTION.md
+++ b/docs/VOICE_COMMAND_EXECUTION.md
@@ -27,7 +27,7 @@ Pattern-based natural language parser for voice transcriptions.
 
 **Limitations:**
 - Fixed patterns, less flexible with variations
-- **Recommendation:** Use `voice_command_ai_parser` for complex commands
+- **Recommendation:** Use `voice_command_ai_parser_activate` for complex commands
 
 ---
 
@@ -171,7 +171,7 @@ Fast-Whisper (speech-to-text)
    │ Command Parsing (Choose one)        │
    ├─────────────────────────────────────┤
    │ 1. voice_command_parser (fast)      │
-   │ 2. voice_command_ai_parser (smart)  │
+   │ 2. voice_command_ai_parser_activate (smart)  │
    └─────────────────────────────────────┘
       ↓
    Parsed Command
@@ -184,7 +184,7 @@ Fast-Whisper (speech-to-text)
    ├─ Updates session context
    └─ Confidence score
       ↓
-voice_command_executor
+voice_command_executor_activate
    ├─ Resolves entity ID: bedroom light → light.bedroom
    ├─ Calls Home Assistant: light.turn_on
    ├─ Returns: success/failure
@@ -279,7 +279,7 @@ curl -X POST http://localhost:7123/api/tools/call \
 curl -X POST http://localhost:7123/api/tools/call \
   -H "Content-Type: application/json" \
   -d '{
-    "name": "voice_command_executor",
+    "name": "voice_command_executor_activate",
     "arguments": {
       "intent": "set_temperature",
       "action": "set_temperature",
@@ -292,7 +292,7 @@ curl -X POST http://localhost:7123/api/tools/call \
 curl -X POST http://localhost:7123/api/tools/call \
   -H "Content-Type: application/json" \
   -d '{
-    "name": "voice_command_ai_parser",
+    "name": "voice_command_ai_parser_activate",
     "arguments": {
       "transcription": "it'\''s cold, make it warmer please",
       "context": {

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -76,7 +76,7 @@ router.get("/list_devices", middleware.authenticate, async (req, res) => {
 // Device control endpoint
 router.post("/control", middleware.authenticate, async (req, res) => {
   try {
-    const tool = tools.find((t: Tool) => t.name === "control");
+    const tool = tools.find((t: Tool) => t.name === "control_activate");
     if (!tool) {
       res.status(404).json({
         success: false,

--- a/src/mcp/schema.ts
+++ b/src/mcp/schema.ts
@@ -36,7 +36,7 @@ export const MCP_SCHEMA = {
       },
     },
     {
-      name: "control",
+      name: "control_activate",
       description: "Control Home Assistant entities (lights, climate, etc.)",
       parameters: {
         type: "object",
@@ -107,7 +107,7 @@ export const MCP_SCHEMA = {
       },
     },
     {
-      name: "automation_config",
+      name: "automation_config_modify",
       description: "Manage Home Assistant automations",
       parameters: {
         type: "object",
@@ -137,8 +137,8 @@ export const MCP_SCHEMA = {
       },
     },
     {
-      name: "addon_management",
-      description: "Manage Home Assistant add-ons",
+      name: "addon_modify",
+      description: "Manage Home Assistant add-ons (install, uninstall, start, stop, restart)",
       parameters: {
         type: "object",
         properties: {
@@ -153,8 +153,8 @@ export const MCP_SCHEMA = {
       },
     },
     {
-      name: "package_management",
-      description: "Manage HACS packages",
+      name: "package_modify",
+      description: "Manage HACS packages (install, uninstall, update)",
       parameters: {
         type: "object",
         properties: {
@@ -173,8 +173,8 @@ export const MCP_SCHEMA = {
       },
     },
     {
-      name: "scene_control",
-      description: "Manage and activate scenes",
+      name: "scene_activate",
+      description: "Activate a Home Assistant scene",
       parameters: {
         type: "object",
         properties: {
@@ -188,7 +188,7 @@ export const MCP_SCHEMA = {
       },
     },
     {
-      name: "notify",
+      name: "notify_activate",
       description: "Send notifications through Home Assistant",
       parameters: {
         type: "object",
@@ -205,7 +205,7 @@ export const MCP_SCHEMA = {
       },
     },
     {
-      name: "history",
+      name: "get_history",
       description: "Retrieve historical data for entities",
       parameters: {
         type: "object",

--- a/src/routes/tool.routes.ts
+++ b/src/routes/tool.routes.ts
@@ -51,7 +51,7 @@ router.post("/control", async (req, res) => {
       });
     }
 
-    const tool = tools.find((t) => t.name === "control");
+    const tool = tools.find((t) => t.name === "control_activate");
     if (!tool) {
       return res.status(404).json({
         success: false,

--- a/src/tools/addon.tool.ts
+++ b/src/tools/addon.tool.ts
@@ -1,116 +1,158 @@
 import { z } from "zod";
-import { Tool, AddonParams, HassAddonResponse, HassAddonInfoResponse } from "../types/index";
+import { Tool, HassAddonResponse, HassAddonInfoResponse } from "../types/index";
 import { APP_CONFIG } from "../config/app.config";
+
+const addonReadSchema = z.object({
+  action: z.enum(["list", "info"]).describe("Read action to perform"),
+  slug: z.string().optional().describe("Add-on slug (required for 'info')"),
+});
+
+const addonModifySchema = z.object({
+  action: z.enum(["install", "uninstall", "start", "stop", "restart"]).describe(
+    "Lifecycle action to perform",
+  ),
+  slug: z.string().describe("Add-on slug"),
+  version: z.string().optional().describe("Version to install (only for 'install')"),
+});
+
+type AddonReadParams = z.infer<typeof addonReadSchema>;
+type AddonModifyParams = z.infer<typeof addonModifySchema>;
+
+async function executeAddonRead(params: AddonReadParams): Promise<string> {
+  try {
+    if (params.action === "list") {
+      const response = await fetch(`${APP_CONFIG.HASS_HOST}/api/hassio/store`, {
+        headers: {
+          Authorization: `Bearer ${APP_CONFIG.HASS_TOKEN}`,
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch add-ons: ${response.statusText}`);
+      }
+
+      const data = (await response.json()) as HassAddonResponse;
+      return JSON.stringify({
+        success: true,
+        addons: data.data.addons.map((addon) => ({
+          name: addon.name,
+          slug: addon.slug,
+          description: addon.description,
+          version: addon.version,
+          installed: addon.installed,
+          available: addon.available,
+          state: addon.state,
+        })),
+      });
+    }
+
+    // info
+    if (!params.slug) {
+      throw new Error("Add-on slug is required for 'info'");
+    }
+
+    const response = await fetch(
+      `${APP_CONFIG.HASS_HOST}/api/hassio/addons/${params.slug}/info`,
+      {
+        headers: {
+          Authorization: `Bearer ${APP_CONFIG.HASS_TOKEN}`,
+          "Content-Type": "application/json",
+        },
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to get add-on info: ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as HassAddonInfoResponse;
+    return JSON.stringify({ success: true, data: data.data });
+  } catch (error) {
+    return JSON.stringify({
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error occurred",
+    });
+  }
+}
+
+async function executeAddonModify(params: AddonModifyParams): Promise<string> {
+  try {
+    let endpoint = "";
+    const body: Record<string, any> = {};
+
+    switch (params.action) {
+      case "install":
+        endpoint = `/api/hassio/addons/${params.slug}/install`;
+        if (params.version) body.version = params.version;
+        break;
+      case "uninstall":
+        endpoint = `/api/hassio/addons/${params.slug}/uninstall`;
+        break;
+      case "start":
+        endpoint = `/api/hassio/addons/${params.slug}/start`;
+        break;
+      case "stop":
+        endpoint = `/api/hassio/addons/${params.slug}/stop`;
+        break;
+      case "restart":
+        endpoint = `/api/hassio/addons/${params.slug}/restart`;
+        break;
+    }
+
+    const response = await fetch(`${APP_CONFIG.HASS_HOST}${endpoint}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${APP_CONFIG.HASS_TOKEN}`,
+        "Content-Type": "application/json",
+      },
+      ...(Object.keys(body).length > 0 && { body: JSON.stringify(body) }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to ${params.action} add-on: ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as HassAddonInfoResponse;
+    return JSON.stringify({
+      success: true,
+      message: `Successfully ${params.action}ed add-on ${params.slug}`,
+      data: data.data,
+    });
+  } catch (error) {
+    return JSON.stringify({
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error occurred",
+    });
+  }
+}
 
 export const addonTool: Tool = {
   name: "addon",
-  description: "Manage Home Assistant add-ons - install, uninstall, start, stop and manage installed add-ons",
+  description: "List Home Assistant add-ons or get info on a specific add-on",
   annotations: {
-    title: "Add-on Management",
-    description: "Install and manage Home Assistant add-ons with lifecycle control",
+    title: "Add-on Inventory",
+    description: "Read-only access to Supervisor add-on store and per-add-on info",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  parameters: addonReadSchema,
+  execute: executeAddonRead,
+};
+
+export const addonModifyTool: Tool = {
+  name: "addon_modify",
+  description: "Install, uninstall, start, stop, or restart Home Assistant add-ons",
+  annotations: {
+    title: "Add-on Lifecycle",
+    description: "Modify Supervisor add-on installation and runtime state",
     readOnlyHint: false,
     destructiveHint: true,
     idempotentHint: false,
     openWorldHint: true,
   },
-  parameters: z.object({
-    action: z
-      .enum(["list", "info", "install", "uninstall", "start", "stop", "restart"])
-      .describe("Action to perform with add-on"),
-    slug: z.string().optional().describe("Add-on slug (required for all actions except list)"),
-    version: z.string().optional().describe("Version to install (only for install action)"),
-  }),
-  execute: async (params: AddonParams) => {
-    try {
-      if (params.action === "list") {
-        const response = await fetch(`${APP_CONFIG.HASS_HOST}/api/hassio/store`, {
-          headers: {
-            Authorization: `Bearer ${APP_CONFIG.HASS_TOKEN}`,
-            "Content-Type": "application/json",
-          },
-        });
-
-        if (!response.ok) {
-          throw new Error(`Failed to fetch add-ons: ${response.statusText}`);
-        }
-
-        const data = (await response.json()) as HassAddonResponse;
-        return JSON.stringify({
-          success: true,
-          addons: data.data.addons.map((addon) => ({
-            name: addon.name,
-            slug: addon.slug,
-            description: addon.description,
-            version: addon.version,
-            installed: addon.installed,
-            available: addon.available,
-            state: addon.state,
-          })),
-        });
-      } else {
-        if (!params.slug) {
-          throw new Error("Add-on slug is required for this action");
-        }
-
-        let endpoint = "";
-        let method = "GET";
-        const body: Record<string, any> = {};
-
-        switch (params.action) {
-          case "info":
-            endpoint = `/api/hassio/addons/${params.slug}/info`;
-            break;
-          case "install":
-            endpoint = `/api/hassio/addons/${params.slug}/install`;
-            method = "POST";
-            if (params.version) {
-              body.version = params.version;
-            }
-            break;
-          case "uninstall":
-            endpoint = `/api/hassio/addons/${params.slug}/uninstall`;
-            method = "POST";
-            break;
-          case "start":
-            endpoint = `/api/hassio/addons/${params.slug}/start`;
-            method = "POST";
-            break;
-          case "stop":
-            endpoint = `/api/hassio/addons/${params.slug}/stop`;
-            method = "POST";
-            break;
-          case "restart":
-            endpoint = `/api/hassio/addons/${params.slug}/restart`;
-            method = "POST";
-            break;
-        }
-
-        const response = await fetch(`${APP_CONFIG.HASS_HOST}${endpoint}`, {
-          method,
-          headers: {
-            Authorization: `Bearer ${APP_CONFIG.HASS_TOKEN}`,
-            "Content-Type": "application/json",
-          },
-          ...(Object.keys(body).length > 0 && { body: JSON.stringify(body) }),
-        });
-
-        if (!response.ok) {
-          throw new Error(`Failed to ${params.action} add-on: ${response.statusText}`);
-        }
-
-        const data = (await response.json()) as HassAddonInfoResponse;
-        return JSON.stringify({
-          success: true,
-          message: `Successfully ${params.action}ed add-on ${params.slug}`,
-          data: data.data,
-        });
-      }
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
-      return JSON.stringify({
-        success: false,
-        error: errorMessage,
-      });
-    }
-  },
+  parameters: addonModifySchema,
+  execute: executeAddonModify,
 };

--- a/src/tools/automation-config.tool.ts
+++ b/src/tools/automation-config.tool.ts
@@ -198,8 +198,8 @@ const _automationConfigSchema = z
   .passthrough()
   .describe("Automation configuration (required for create and update)");
 
-export const automationConfigTool: Tool = {
-  name: "automation_config",
+export const automationConfigModifyTool: Tool = {
+  name: "automation_config_modify",
   description:
     "Advanced automation configuration and management - create, update, duplicate, and delete automations",
   annotations: {

--- a/src/tools/control.tool.ts
+++ b/src/tools/control.tool.ts
@@ -19,8 +19,8 @@ const allCommands = [
   "set_humidity",
 ] as const;
 
-export const controlTool: Tool = {
-  name: "control",
+export const controlActivateTool: Tool = {
+  name: "control_activate",
   description:
     "Control Home Assistant devices and services - universal control endpoint for turning on/off, toggling, setting positions, temperatures, and more",
   annotations: {

--- a/src/tools/dashboard.tool.ts
+++ b/src/tools/dashboard.tool.ts
@@ -1,9 +1,11 @@
 /**
- * Dashboard Management Tool for Home Assistant
+ * Dashboard Management Tools for Home Assistant
  *
- * List, view, edit, and import/export Lovelace dashboard configurations.
+ * Split into:
+ * - `dashboard` (read-only): list, get_config, export_yaml
+ * - `dashboard_modify`: update_config, import_yaml (both replace entire dashboard config)
+ *
  * Uses the WebSocket API since Lovelace endpoints are not available via REST.
- * Supports JSON and YAML formats for dashboard configs.
  */
 
 import { z } from "zod";
@@ -13,27 +15,33 @@ import { logger } from "../utils/logger.js";
 import { get_hass_ws } from "../hass/websocket-manager.js";
 import { Tool } from "../types/index.js";
 
-const dashboardSchema = z.object({
-  action: z
-    .enum(["list", "get_config", "update_config", "export_yaml", "import_yaml"])
-    .describe("Action to perform on dashboards"),
+const dashboardReadSchema = z.object({
+  action: z.enum(["list", "get_config", "export_yaml"]).describe("Read action to perform"),
   url_path: z
     .string()
     .optional()
     .describe(
-      "Dashboard URL path (omit for the default dashboard). Use the 'list' action to discover available dashboards.",
+      "Dashboard URL path (omit for the default dashboard). Use 'list' to discover available dashboards.",
     ),
+});
+
+const dashboardModifySchema = z.object({
+  action: z
+    .enum(["update_config", "import_yaml"])
+    .describe("Modify action — replaces entire dashboard config"),
+  url_path: z.string().optional().describe("Dashboard URL path (omit for default)"),
   config: z
     .record(z.string(), z.unknown())
     .optional()
-    .describe("Dashboard configuration object (required for update_config action)"),
+    .describe("Dashboard configuration object (required for update_config)"),
   yaml_content: z
     .string()
     .optional()
-    .describe("YAML string of dashboard configuration (required for import_yaml action)"),
+    .describe("YAML string of dashboard configuration (required for import_yaml)"),
 });
 
-type DashboardParams = z.infer<typeof dashboardSchema>;
+type DashboardReadParams = z.infer<typeof dashboardReadSchema>;
+type DashboardModifyParams = z.infer<typeof dashboardModifySchema>;
 
 async function fetchDashboardConfig(urlPath?: string): Promise<Record<string, unknown>> {
   const hass = await get_hass_ws();
@@ -59,7 +67,7 @@ async function saveDashboardConfig(
   await hass.send(msg);
 }
 
-async function executeDashboard(params: DashboardParams): Promise<string> {
+async function executeDashboardRead(params: DashboardReadParams): Promise<string> {
   try {
     switch (params.action) {
       case "list": {
@@ -67,58 +75,51 @@ async function executeDashboard(params: DashboardParams): Promise<string> {
         const dashboards = await hass.send({ type: "lovelace/dashboards/list" });
         return JSON.stringify({ dashboards });
       }
-
       case "get_config": {
         const config = await fetchDashboardConfig(params.url_path);
         return JSON.stringify(config, null, 2);
       }
+      case "export_yaml": {
+        const config = await fetchDashboardConfig(params.url_path);
+        const yaml = yamlStringify(config);
+        return JSON.stringify({ yaml });
+      }
+    }
+  } catch (error) {
+    if (error instanceof UserError) throw error;
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error(`Dashboard read failed: ${message}`);
+    throw new UserError(`Dashboard read failed: ${message}`);
+  }
+}
 
+async function executeDashboardModify(params: DashboardModifyParams): Promise<string> {
+  try {
+    switch (params.action) {
       case "update_config": {
         if (!params.config) {
-          throw new UserError(
-            "The 'config' parameter is required for update_config action",
-          );
+          throw new UserError("The 'config' parameter is required for update_config action");
         }
-
         await saveDashboardConfig(params.config, params.url_path);
         return JSON.stringify({
           success: true,
           message: `Dashboard ${params.url_path ?? "default"} config updated`,
         });
       }
-
-      case "export_yaml": {
-        const config = await fetchDashboardConfig(params.url_path);
-        const yaml = yamlStringify(config);
-        return JSON.stringify({ yaml });
-      }
-
       case "import_yaml": {
         if (!params.yaml_content) {
-          throw new UserError(
-            "The 'yaml_content' parameter is required for import_yaml action",
-          );
+          throw new UserError("The 'yaml_content' parameter is required for import_yaml action");
         }
-
         let config: unknown;
         try {
           config = yamlParse(params.yaml_content);
         } catch (parseError) {
-          throw new UserError(
-            `Invalid YAML: ${(parseError as Error).message}`,
-          );
+          throw new UserError(`Invalid YAML: ${(parseError as Error).message}`);
         }
-
         if (config == null || typeof config !== "object" || Array.isArray(config)) {
-          throw new UserError(
-            "YAML must parse to an object (the dashboard configuration)",
-          );
+          throw new UserError("YAML must parse to an object (the dashboard configuration)");
         }
-
-        await saveDashboardConfig(
-          config as Record<string, unknown>,
-          params.url_path,
-        );
+        await saveDashboardConfig(config as Record<string, unknown>, params.url_path);
         return JSON.stringify({
           success: true,
           message: `Dashboard ${params.url_path ?? "default"} config imported from YAML`,
@@ -128,22 +129,37 @@ async function executeDashboard(params: DashboardParams): Promise<string> {
   } catch (error) {
     if (error instanceof UserError) throw error;
     const message = error instanceof Error ? error.message : String(error);
-    logger.error(`Dashboard operation failed: ${message}`);
-    throw new UserError(`Dashboard operation failed: ${message}`);
+    logger.error(`Dashboard modify failed: ${message}`);
+    throw new UserError(`Dashboard modify failed: ${message}`);
   }
 }
 
 export const dashboardTool: Tool = {
   name: "dashboard",
   description:
-    "Manage Home Assistant Lovelace dashboards. List all dashboards, get or update their configuration, and import/export configs as YAML. Note: update_config and import_yaml replace the entire dashboard config — always get the current config first, modify it, then update.",
-  parameters: dashboardSchema,
-  execute: executeDashboard,
+    "List Home Assistant Lovelace dashboards or read a dashboard's configuration (JSON or YAML export).",
+  parameters: dashboardReadSchema,
+  execute: executeDashboardRead,
   annotations: {
-    title: "Dashboard Management",
+    title: "Dashboard Inventory",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+};
+
+export const dashboardModifyTool: Tool = {
+  name: "dashboard_modify",
+  description:
+    "Replace a Home Assistant Lovelace dashboard's configuration (from a JSON object or YAML string). Both actions overwrite the entire dashboard config — always read first, then modify, then update.",
+  parameters: dashboardModifySchema,
+  execute: executeDashboardModify,
+  annotations: {
+    title: "Dashboard Modify",
     readOnlyHint: false,
     destructiveHint: true,
-    idempotentHint: false,
+    idempotentHint: true,
     openWorldHint: true,
   },
 };

--- a/src/tools/homeassistant/alarm.tool.ts
+++ b/src/tools/homeassistant/alarm.tool.ts
@@ -1,8 +1,9 @@
 /**
- * Alarm Control Panel Tool for Home Assistant
+ * Alarm Control Panel tools for Home Assistant
  *
- * This tool allows controlling alarm systems in Home Assistant.
- * Supports arming (away/home/night), disarming, and triggering alarms.
+ * Split into:
+ * - `alarms` (read-only): list, get
+ * - `alarms_activate`: arm_*, disarm, trigger (destructive — sounds the alarm or disarms security)
  */
 
 import { z } from "zod";
@@ -10,7 +11,6 @@ import { logger } from "../../utils/logger.js";
 import { get_hass } from "../../hass/index.js";
 import { Tool } from "../../types/index.js";
 
-// Real Home Assistant API service
 class HomeAssistantAlarmService {
   async getAlarms(): Promise<Record<string, unknown>[]> {
     try {
@@ -51,8 +51,7 @@ class HomeAssistantAlarmService {
   ): Promise<boolean> {
     try {
       const hass = await get_hass();
-      const serviceData = { entity_id, ...data };
-      await hass.callService("alarm_control_panel", service, serviceData);
+      await hass.callService("alarm_control_panel", service, { entity_id, ...data });
       return true;
     } catch (error) {
       logger.error(`Failed to call service ${service} on ${entity_id}:`, error);
@@ -61,15 +60,16 @@ class HomeAssistantAlarmService {
   }
 }
 
-// Singleton instance
 const haAlarmService = new HomeAssistantAlarmService();
 
-// Define the schema for our tool parameters using Zod
-const alarmControlSchema = z.object({
+const alarmsReadSchema = z.object({
+  action: z.enum(["list", "get"]).describe("Read action"),
+  entity_id: z.string().optional().describe("Alarm entity_id (required for 'get')"),
+});
+
+const alarmsActivateSchema = z.object({
   action: z
     .enum([
-      "list",
-      "get",
       "alarm_disarm",
       "alarm_arm_home",
       "alarm_arm_away",
@@ -78,77 +78,41 @@ const alarmControlSchema = z.object({
       "alarm_arm_custom_bypass",
       "alarm_trigger",
     ])
-    .describe("The action to perform"),
-  entity_id: z
-    .string()
-    .optional()
-    .describe("The entity ID of the alarm (required for most actions)"),
-  code: z.string().optional().describe("Optional security code for the alarm system"),
+    .describe("Activation action"),
+  entity_id: z.string().describe("Alarm entity_id"),
+  code: z.string().optional().describe("Optional security code"),
 });
 
-type AlarmControlInput = z.infer<typeof alarmControlSchema>;
+type AlarmsReadParams = z.infer<typeof alarmsReadSchema>;
+type AlarmsActivateParams = z.infer<typeof alarmsActivateSchema>;
 
-// Main tool execution function
-async function execute(params: AlarmControlInput): Promise<string> {
-  const { action, entity_id, code } = params;
+async function executeAlarmsRead(params: AlarmsReadParams): Promise<string> {
+  if (params.action === "list") {
+    const alarms = await haAlarmService.getAlarms();
+    return JSON.stringify({ success: true, alarms, count: alarms.length }, null, 2);
+  }
+  if (!params.entity_id) {
+    return JSON.stringify({ success: false, error: "entity_id is required for get action" });
+  }
+  const alarm = await haAlarmService.getAlarm(params.entity_id);
+  if (!alarm) {
+    return JSON.stringify({ success: false, error: `Alarm ${params.entity_id} not found` });
+  }
+  return JSON.stringify({ success: true, alarm }, null, 2);
+}
 
+async function executeAlarmsActivate(params: AlarmsActivateParams): Promise<string> {
   try {
-    switch (action) {
-      case "list": {
-        const alarms = await haAlarmService.getAlarms();
-        return JSON.stringify(
-          {
-            success: true,
-            alarms: alarms,
-            count: alarms.length,
-          },
-          null,
-          2,
-        );
-      }
-
-      case "get": {
-        if (!entity_id) {
-          return JSON.stringify({ success: false, error: "entity_id is required for get action" });
-        }
-        const alarm = await haAlarmService.getAlarm(entity_id);
-        if (!alarm) {
-          return JSON.stringify({ success: false, error: `Alarm ${entity_id} not found` });
-        }
-        return JSON.stringify({ success: true, alarm: alarm }, null, 2);
-      }
-
-      case "alarm_disarm":
-      case "alarm_arm_home":
-      case "alarm_arm_away":
-      case "alarm_arm_night":
-      case "alarm_arm_vacation":
-      case "alarm_arm_custom_bypass":
-      case "alarm_trigger": {
-        if (!entity_id) {
-          return JSON.stringify({
-            success: false,
-            error: `entity_id is required for ${action} action`,
-          });
-        }
-        const serviceData = code ? { code } : {};
-        const success = await haAlarmService.callService(action, entity_id, serviceData);
-        return JSON.stringify({
-          success,
-          message: success
-            ? `Successfully executed ${action} on ${entity_id}`
-            : `Failed to execute ${action} on ${entity_id}`,
-        });
-      }
-
-      default:
-        // `action` narrows to never after the exhaustive switch; cast to
-        // string so the template literal is valid at runtime if a non-enum
-        // value somehow slips through (e.g. an unchecked JSON-RPC payload).
-        return JSON.stringify({ success: false, error: `Unknown action: ${String(action)}` });
-    }
+    const serviceData = params.code ? { code: params.code } : {};
+    const success = await haAlarmService.callService(params.action, params.entity_id, serviceData);
+    return JSON.stringify({
+      success,
+      message: success
+        ? `Successfully executed ${params.action} on ${params.entity_id}`
+        : `Failed to execute ${params.action} on ${params.entity_id}`,
+    });
   } catch (error) {
-    logger.error("Error in alarm control tool:", error);
+    logger.error("Error in alarm activate tool:", error);
     return JSON.stringify({
       success: false,
       error: error instanceof Error ? error.message : "Unknown error occurred",
@@ -156,19 +120,33 @@ async function execute(params: AlarmControlInput): Promise<string> {
   }
 }
 
-// Export the tool object
-export const alarmControlTool: Tool = {
-  name: "alarm_control",
-  description:
-    "Control alarm systems in Home Assistant. Supports arming in different modes (home, away, night, vacation, custom bypass), disarming, and triggering alarms. Some systems may require a security code. Actions include: list (get all alarms), get (get specific alarm info), alarm_disarm, alarm_arm_home, alarm_arm_away, alarm_arm_night, alarm_arm_vacation, alarm_arm_custom_bypass, and alarm_trigger.",
+export const alarmsTool: Tool = {
+  name: "alarms",
+  description: "List all alarm panels or get the state of a specific alarm panel.",
   annotations: {
-    title: "Alarm Control",
-    description: "Manage security alarms - arm in different modes, disarm, and check status",
+    title: "Alarms Inventory",
+    description: "Read-only access to alarm panel entities",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  parameters: alarmsReadSchema,
+  execute: executeAlarmsRead,
+};
+
+export const alarmsActivateTool: Tool = {
+  name: "alarms_activate",
+  description:
+    "Arm in various modes (home, away, night, vacation, custom bypass), disarm, or trigger an alarm. Security-sensitive operations.",
+  annotations: {
+    title: "Alarms Activate",
+    description: "Arm/disarm/trigger security alarms (security-sensitive)",
     readOnlyHint: false,
     destructiveHint: true,
     idempotentHint: false,
     openWorldHint: true,
   },
-  parameters: alarmControlSchema,
-  execute,
+  parameters: alarmsActivateSchema,
+  execute: executeAlarmsActivate,
 };

--- a/src/tools/homeassistant/animation-control.tool.ts
+++ b/src/tools/homeassistant/animation-control.tool.ts
@@ -34,17 +34,19 @@ const animationActivateSchema = z.object({
 type AnimationReadParams = z.infer<typeof animationReadSchema>;
 type AnimationActivateParams = z.infer<typeof animationActivateSchema>;
 
-async function executeAnimationRead(_params: AnimationReadParams): Promise<string> {
+function executeAnimationRead(_params: AnimationReadParams): Promise<string> {
   const manager = AnimationManager.getInstance();
   const active = manager.listAnimations();
-  return JSON.stringify(
-    {
-      success: true,
-      running_count: active.length,
-      animations: active,
-    },
-    null,
-    2,
+  return Promise.resolve(
+    JSON.stringify(
+      {
+        success: true,
+        running_count: active.length,
+        animations: active,
+      },
+      null,
+      2,
+    ),
   );
 }
 

--- a/src/tools/homeassistant/animation-control.tool.ts
+++ b/src/tools/homeassistant/animation-control.tool.ts
@@ -1,3 +1,10 @@
+/**
+ * Animation Control tools for Home Assistant
+ *
+ * Split into:
+ * - `animation_control` (read-only): list running background animations
+ * - `animation_control_activate`: start, stop, stop_all (all affect lights' ongoing behavior)
+ */
 
 import { z } from "zod";
 import { Tool } from "../../types/index.js";
@@ -6,189 +13,188 @@ import { logger } from "../../utils/logger.js";
 import { AnimationManager } from "../../helpers/animation-manager.js";
 import { LightManager } from "../../helpers/light-manager.js";
 
-const AnimationActionSchema = z.enum(["start", "stop", "list", "stop_all"]);
-
-// Config for starting an animation
 const AnimationConfigSchema = z.object({
-    target: z.string().describe("Target Area or Entity"),
-    type: z.enum(["showcase", "custom"]).default("showcase"),
-    // Custom type params
-    colors: z.array(z.string()).optional().describe("For 'custom': Palette of colors"),
-    strategy: z.enum(["random", "round_robin"]).optional().default("random"),
-    interval_sec: z.number().optional().default(5).describe("Time between changes (seconds)"),
+  target: z.string().describe("Target Area or Entity"),
+  type: z.enum(["showcase", "custom"]).default("showcase"),
+  colors: z.array(z.string()).optional().describe("For 'custom': Palette of colors"),
+  strategy: z.enum(["random", "round_robin"]).optional().default("random"),
+  interval_sec: z.number().optional().default(5).describe("Time between changes (seconds)"),
 });
 
-const AnimationControlParamsSchema = z.object({
-    action: AnimationActionSchema,
-    config: AnimationConfigSchema.optional().describe("Required for 'start' action"),
-    animation_id: z.string().optional().describe("Required for 'stop' action"),
+const animationReadSchema = z.object({
+  action: z.literal("list").describe("List currently running background animations"),
 });
 
-type AnimationControlParams = z.infer<typeof AnimationControlParamsSchema>;
+const animationActivateSchema = z.object({
+  action: z.enum(["start", "stop", "stop_all"]).describe("Activation action"),
+  config: AnimationConfigSchema.optional().describe("Required for 'start' action"),
+  animation_id: z.string().optional().describe("Required for 'stop' action"),
+});
+
+type AnimationReadParams = z.infer<typeof animationReadSchema>;
+type AnimationActivateParams = z.infer<typeof animationActivateSchema>;
+
+async function executeAnimationRead(_params: AnimationReadParams): Promise<string> {
+  const manager = AnimationManager.getInstance();
+  const active = manager.listAnimations();
+  return JSON.stringify(
+    {
+      success: true,
+      running_count: active.length,
+      animations: active,
+    },
+    null,
+    2,
+  );
+}
+
+async function executeAnimationActivate(params: AnimationActivateParams): Promise<string> {
+  const manager = AnimationManager.getInstance();
+
+  if (params.action === "stop") {
+    if (!params.animation_id) {
+      return JSON.stringify({ success: false, error: "animation_id required for stop action" });
+    }
+    const success = manager.stopAnimation(params.animation_id);
+    return JSON.stringify({ success, message: success ? "Animation stopped" : "ID not found" });
+  }
+
+  if (params.action === "stop_all") {
+    const count = manager.stopAll();
+    return JSON.stringify({ success: true, message: `Stopped ${count} animations` });
+  }
+
+  // start
+  if (!params.config) {
+    return JSON.stringify({ success: false, error: "config required for start action" });
+  }
+
+  const { target, type, colors, strategy, interval_sec } = params.config;
+  const hass = await get_hass();
+  const allStates = await hass.getStates();
+
+  const lowerTarget = target.toLowerCase();
+  const targetLights = allStates.filter((s) => {
+    if (!s.entity_id.startsWith("light.")) return false;
+    const areaId = (s.attributes as { area_id?: string }).area_id;
+    const friendlyName = (s.attributes as { friendly_name?: string }).friendly_name || "";
+    if (areaId && (areaId === lowerTarget || areaId.toLowerCase().includes(lowerTarget)))
+      return true;
+    if (friendlyName.toLowerCase().includes(lowerTarget)) return true;
+    if (s.entity_id === target) return true;
+    return false;
+  });
+
+  if (targetLights.length === 0) {
+    return JSON.stringify({ success: false, error: `No lights found for target '${target}'` });
+  }
+
+  let tickFn: () => Promise<void>;
+
+  if (type === "showcase") {
+    let stageIndex = 0;
+    const stages = [
+      { name: "Sunrise", colors: ["#FF4500", "#FF8C00", "#FFD700"], strategy: "round_robin" },
+      { name: "Daylight", colors: ["#FFFFFF", "#87CEEB"], strategy: "random" },
+      { name: "Ocean", colors: ["#00008B", "#008B8B", "#00FFFF"], strategy: "round_robin" },
+      { name: "Cyberpunk", colors: ["#FF00FF", "#00FFFF", "#800080"], strategy: "random" },
+      { name: "Relax", kelvin: 2700, brightness: 40 },
+    ];
+
+    tickFn = async () => {
+      const stage = stages[stageIndex];
+      logger.info(`Animation Tick: ${stage.name}`);
+
+      if ((stage as { colors?: string[] }).colors) {
+        const s = stage as { colors: string[]; strategy: string };
+        const promises = targetLights.map(async (light, i) => {
+          let hex: string;
+          if (s.strategy === "round_robin") hex = s.colors[i % s.colors.length];
+          else hex = s.colors[Math.floor(Math.random() * s.colors.length)];
+          const res = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+          const rgb = res
+            ? [parseInt(res[1], 16), parseInt(res[2], 16), parseInt(res[3], 16)]
+            : [255, 255, 255];
+          await LightManager.applyLightState(light, {
+            rgb_color: rgb as [number, number, number],
+            brightness_pct: 80,
+            transition: (interval_sec || 5) - 1,
+          });
+        });
+        await Promise.all(promises);
+      } else {
+        const s = stage as { kelvin: number; brightness: number };
+        const promises = targetLights.map(async (light) => {
+          await LightManager.applyLightState(light, {
+            color_temp_kelvin: s.kelvin,
+            brightness_pct: s.brightness,
+            transition: (interval_sec || 5) - 1,
+          });
+        });
+        await Promise.all(promises);
+      }
+      stageIndex = (stageIndex + 1) % stages.length;
+    };
+  } else {
+    if (!colors || colors.length === 0) {
+      return JSON.stringify({ success: false, error: "Colors required for custom type" });
+    }
+    const rgbPalette = colors
+      .map((hex) => {
+        const res = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+        return res ? [parseInt(res[1], 16), parseInt(res[2], 16), parseInt(res[3], 16)] : null;
+      })
+      .filter((c) => c !== null) as [number, number, number][];
+
+    tickFn = async () => {
+      const promises = targetLights.map(async (light) => {
+        const rgb: [number, number, number] =
+          strategy === "round_robin"
+            ? rgbPalette[Math.floor(Math.random() * rgbPalette.length)]
+            : rgbPalette[Math.floor(Math.random() * rgbPalette.length)];
+        await LightManager.applyLightState(light, {
+          rgb_color: rgb,
+          transition: (interval_sec || 5) - 1,
+        });
+      });
+      await Promise.all(promises);
+    };
+  }
+
+  const id = manager.startAnimation(type, target, (interval_sec || 5) * 1000, tickFn);
+  return JSON.stringify({
+    success: true,
+    message: `Started ${type} animation on ${targetLights.length} lights`,
+    animation_id: id,
+  });
+}
 
 export const animationControlTool: Tool = {
-    name: "animation_control",
-    description: "Start, stop, and manage background light animations (Endless loops).",
-    parameters: AnimationControlParamsSchema,
-    annotations: {
-        title: "Animation Control",
-        description: "Manage background light animations",
-        destructiveHint: false,
-        idempotentHint: false,
-    },
-    execute: async (params: AnimationControlParams) => {
-        const manager = AnimationManager.getInstance();
+  name: "animation_control",
+  description: "List currently running background light animations.",
+  parameters: animationReadSchema,
+  annotations: {
+    title: "Animation Control Inventory",
+    description: "Read-only list of active background animations",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  execute: executeAnimationRead,
+};
 
-        if (params.action === "list") {
-            const active = manager.listAnimations();
-            return JSON.stringify({
-                success: true,
-                running_count: active.length,
-                animations: active
-            }, null, 2);
-        }
-
-        if (params.action === "stop") {
-            if (!params.animation_id) {
-                return JSON.stringify({ success: false, error: "animation_id required for stop action" });
-            }
-            const success = manager.stopAnimation(params.animation_id);
-            return JSON.stringify({ success, message: success ? "Animation stopped" : "ID not found" });
-        }
-
-        if (params.action === "stop_all") {
-            const count = manager.stopAll();
-            return JSON.stringify({ success: true, message: `Stopped ${count} animations` });
-        }
-
-        if (params.action === "start") {
-            if (!params.config) {
-                return JSON.stringify({ success: false, error: "config required for start action" });
-            }
-
-            const { target, type, colors, strategy, interval_sec } = params.config;
-            const hass = await get_hass();
-            const allStates = await hass.getStates();
-
-            // Target Resolution
-            let targetLights: any[] = [];
-            const lowerTarget = target.toLowerCase();
-            targetLights = allStates.filter(s => {
-                if (!s.entity_id.startsWith("light.")) return false;
-                const areaId = (s.attributes as any).area_id;
-                const friendlyName = (s.attributes as any).friendly_name || "";
-                if (areaId && (areaId === lowerTarget || areaId.toLowerCase().includes(lowerTarget))) return true;
-                if (friendlyName.toLowerCase().includes(lowerTarget)) return true;
-                // Direct entity match
-                if (s.entity_id === target) return true;
-                return false;
-            });
-
-            if (targetLights.length === 0) {
-                return JSON.stringify({ success: false, error: `No lights found for target '${target}'` });
-            }
-
-            // Logic Construction
-            let tickFn: () => Promise<void>;
-
-            if (type === "showcase") {
-                // Endless Showcase: Cycle through moods
-                // State to track current stage across ticks? 
-                // Actually, AnimationManager runs a function periodically.
-                // If we want a sequenced showcase (Sunrise -> Ocean...), we need state.
-
-                let stageIndex = 0;
-                const stages = [
-                    { name: "Sunrise", colors: ["#FF4500", "#FF8C00", "#FFD700"], strategy: "round_robin" },
-                    { name: "Daylight", colors: ["#FFFFFF", "#87CEEB"], strategy: "random" },
-                    { name: "Ocean", colors: ["#00008B", "#008B8B", "#00FFFF"], strategy: "round_robin" },
-                    { name: "Cyberpunk", colors: ["#FF00FF", "#00FFFF", "#800080"], strategy: "random" },
-                    { name: "Relax", kelvin: 2700, brightness: 40 }
-                ];
-
-                tickFn = async () => {
-                    const stage = stages[stageIndex];
-                    logger.info(`Animation Tick: ${stage.name}`);
-
-                    if ((stage as any).colors) {
-                        // Color Stage
-                        const s = stage as any;
-                        const promises = targetLights.map(async (light, i) => {
-                            let hex: string;
-                            if (s.strategy === "round_robin") hex = s.colors[i % s.colors.length];
-                            else hex = s.colors[Math.floor(Math.random() * s.colors.length)];
-
-                            // Quick Hex Parse
-                            const res = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-                            const rgb = res ? [parseInt(res[1], 16), parseInt(res[2], 16), parseInt(res[3], 16)] : [255, 255, 255];
-
-                            // Apply
-                            await LightManager.applyLightState(light, {
-                                rgb_color: rgb as [number, number, number],
-                                brightness_pct: 80,
-                                transition: (interval_sec || 5) - 1 // Transition slightly shorter than interval
-                            });
-                        });
-                        await Promise.all(promises);
-                    } else {
-                        // Kelvin Stage
-                        const s = stage as any;
-                        const promises = targetLights.map(async (light) => {
-                            await LightManager.applyLightState(light, {
-                                color_temp_kelvin: s.kelvin,
-                                brightness_pct: s.brightness,
-                                transition: (interval_sec || 5) - 1
-                            });
-                        });
-                        await Promise.all(promises);
-                    }
-
-                    // Advance Stage
-                    stageIndex = (stageIndex + 1) % stages.length;
-                };
-            } else {
-                // Custom Type (Single Palette Loop)
-                if (!colors || colors.length === 0) {
-                    return JSON.stringify({ success: false, error: "Colors required for custom type" });
-                }
-
-                // Pre-parse colors
-                const rgbPalette = colors.map(hex => {
-                    const res = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-                    return res ? [parseInt(res[1], 16), parseInt(res[2], 16), parseInt(res[3], 16)] : null;
-                }).filter(c => c !== null) as [number, number, number][];
-
-                tickFn = async () => {
-                    const promises = targetLights.map(async (light, i) => {
-                        let rgb: [number, number, number];
-                        if (strategy === "round_robin") {
-                            // To make round robin 'move', need a shift factor based on time/tick?
-                            // Ideally yes. Let's use a random shift or increment.
-                            // But simple round robin is static if index is static.
-                            // Let's use Random for custom endless to make it alive, OR shift the offset.
-                            // For now: Random is safer for "animation".
-                            rgb = rgbPalette[Math.floor(Math.random() * rgbPalette.length)];
-                        } else {
-                            rgb = rgbPalette[Math.floor(Math.random() * rgbPalette.length)];
-                        }
-
-                        await LightManager.applyLightState(light, {
-                            rgb_color: rgb,
-                            transition: (interval_sec || 5) - 1
-                        });
-                    });
-                    await Promise.all(promises);
-                };
-            }
-
-            const id = manager.startAnimation(type, target, (interval_sec || 5) * 1000, tickFn);
-            return JSON.stringify({
-                success: true,
-                message: `Started ${type} animation on ${targetLights.length} lights`,
-                animation_id: id
-            });
-        }
-
-        return JSON.stringify({ success: false, error: "Invalid action" });
-    },
+export const animationControlActivateTool: Tool = {
+  name: "animation_control_activate",
+  description: "Start, stop, or stop-all background light animations (endless loops).",
+  parameters: animationActivateSchema,
+  annotations: {
+    title: "Animation Control Activate",
+    description: "Start/stop background animations — affects lights' ongoing behavior",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  execute: executeAnimationActivate,
 };

--- a/src/tools/homeassistant/automation.tool.ts
+++ b/src/tools/homeassistant/automation.tool.ts
@@ -1,74 +1,66 @@
 /**
- * Automation Tool for Home Assistant
+ * Automation Tools for Home Assistant
  *
- * This tool manages Home Assistant automations - list, toggle, and trigger.
+ * Split into:
+ * - `automation` (read-only): list
+ * - `automation_modify`: toggle (flips enable/disable; no actions fire)
+ * - `automation_activate`: trigger (fires the automation's actions — real-world via what they do)
  */
 
 import { z } from "zod";
 import { logger } from "../../utils/logger.js";
 
-import { MCPContext } from "../../mcp/types.js";
 import { get_hass } from "../../hass/index.js";
 import { Tool } from "../../types/index.js";
 
-// Define the schema for our tool parameters
-const automationSchema = z.object({
-  action: z.enum(["list", "toggle", "trigger"]).describe("Action to perform with automation"),
+const automationReadSchema = z.object({
+  action: z.literal("list").describe("List configured automations"),
+});
+
+const automationModifySchema = z.object({
+  action: z.literal("toggle").describe("Enable or disable an automation"),
   automation_id: z
     .string()
-    .optional()
     .describe(
-      "Entity ID of the automation, e.g., 'automation.office_carbon_filter_person_detection' (required for toggle and trigger actions). Use the 'entity_id' field from list results.",
+      "Entity ID of the automation, e.g., 'automation.office_carbon_filter_person_detection'.",
     ),
 });
 
-// Infer the type from the schema
-type AutomationParams = z.infer<typeof automationSchema>;
+const automationActivateSchema = z.object({
+  action: z.literal("trigger").describe("Fire the automation's actions now"),
+  automation_id: z
+    .string()
+    .describe(
+      "Entity ID of the automation, e.g., 'automation.office_carbon_filter_person_detection'.",
+    ),
+});
 
-// Shared execution logic
-async function executeAutomationLogic(params: AutomationParams): Promise<string> {
-  logger.debug(`Executing automation logic with params: ${JSON.stringify(params)}`);
+type AutomationReadParams = z.infer<typeof automationReadSchema>;
+type AutomationModifyParams = z.infer<typeof automationModifySchema>;
+type AutomationActivateParams = z.infer<typeof automationActivateSchema>;
 
+async function executeAutomationRead(_params: AutomationReadParams): Promise<string> {
   try {
     const hass = await get_hass();
+    const states = await hass.getStates();
+    const automations = states
+      .filter((state) => state.entity_id.startsWith("automation."))
+      .map((automation) => ({
+        entity_id: automation.entity_id,
+        id: automation.attributes?.id,
+        name: automation.attributes?.friendly_name || automation.entity_id.split(".")[1],
+        state: automation.state,
+        last_triggered: automation.attributes?.last_triggered,
+      }));
 
-    if (params.action === "list") {
-      const states = await hass.getStates();
-      const automations = states
-        .filter((state) => state.entity_id.startsWith("automation."))
-        .map((automation) => ({
-          entity_id: automation.entity_id,
-          id: automation.attributes?.id,
-          name: automation.attributes?.friendly_name || automation.entity_id.split(".")[1],
-          state: automation.state,
-          last_triggered: automation.attributes?.last_triggered,
-        }));
-
-      return JSON.stringify({
-        success: true,
-        automations,
-        total_count: automations.length,
-      });
-    } else {
-      if (!params.automation_id) {
-        throw new Error("Automation ID is required for toggle and trigger actions");
-      }
-
-      const service = params.action === "toggle" ? "toggle" : "trigger";
-      await hass.callService("automation", service, {
-        entity_id: params.automation_id,
-      });
-
-      return JSON.stringify({
-        success: true,
-        message: `Successfully ${service}d automation ${params.automation_id}`,
-        automation_id: params.automation_id,
-        action: params.action,
-      });
-    }
+    return JSON.stringify({
+      success: true,
+      automations,
+      total_count: automations.length,
+    });
   } catch (error) {
     logger.error(
-      `Error in automation logic: ${error instanceof Error ? error.message : String(error)}`,
+      `Error listing automations: ${error instanceof Error ? error.message : String(error)}`,
     );
     return JSON.stringify({
       success: false,
@@ -77,20 +69,75 @@ async function executeAutomationLogic(params: AutomationParams): Promise<string>
   }
 }
 
-// Tool object export (for FastMCP)
+async function callAutomationService(
+  service: "toggle" | "trigger",
+  automation_id: string,
+): Promise<string> {
+  try {
+    const hass = await get_hass();
+    await hass.callService("automation", service, { entity_id: automation_id });
+    return JSON.stringify({
+      success: true,
+      message: `Successfully ${service}d automation ${automation_id}`,
+      automation_id,
+      action: service,
+    });
+  } catch (error) {
+    logger.error(
+      `Error ${service}ing automation: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return JSON.stringify({
+      success: false,
+      message: error instanceof Error ? error.message : "Unknown error occurred",
+    });
+  }
+}
+
 export const automationTool: Tool = {
   name: "automation",
-  description: "Manage Home Assistant automations (list, toggle, trigger)",
+  description: "List Home Assistant automations and their current state.",
   annotations: {
-    title: "Automation Management",
-    description: "List, enable, disable, and trigger Home Assistant automations",
-    readOnlyHint: false,
+    title: "Automation Inventory",
+    description: "Read-only listing of configured automations",
+    readOnlyHint: true,
     destructiveHint: false,
     idempotentHint: true,
     openWorldHint: true,
   },
-  parameters: automationSchema,
-  execute: executeAutomationLogic,
+  parameters: automationReadSchema,
+  execute: executeAutomationRead,
 };
 
+export const automationModifyTool: Tool = {
+  name: "automation_modify",
+  description:
+    "Toggle (enable/disable) a Home Assistant automation. Does not fire the automation's actions.",
+  annotations: {
+    title: "Automation Toggle",
+    description: "Enable or disable an automation",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  parameters: automationModifySchema,
+  execute: (params: AutomationModifyParams) =>
+    callAutomationService("toggle", params.automation_id),
+};
 
+export const automationActivateTool: Tool = {
+  name: "automation_activate",
+  description:
+    "Fire a Home Assistant automation's actions now. Side effects depend on what the automation does (could control devices, send notifications, etc.).",
+  annotations: {
+    title: "Automation Trigger",
+    description: "Fire an automation's actions now",
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  parameters: automationActivateSchema,
+  execute: (params: AutomationActivateParams) =>
+    callAutomationService("trigger", params.automation_id),
+};

--- a/src/tools/homeassistant/climate.tool.ts
+++ b/src/tools/homeassistant/climate.tool.ts
@@ -1,19 +1,17 @@
 /**
- * Climate Control Tool for Home Assistant (fastmcp format)
+ * Climate tools for Home Assistant
  *
- * This tool allows controlling climate devices (thermostats, AC units, etc.)
- * in Home Assistant through the MCP. It supports modes, temperature settings,
- * and fan modes.
+ * Split into:
+ * - `climate` (read-only): list, get
+ * - `climate_activate`: set_hvac_mode, set_temperature, set_fan_mode
  */
 
 import { z } from "zod";
 import { logger } from "../../utils/logger.js";
 
-import { MCPContext } from "../../mcp/types.js";
 import { get_hass } from "../../hass/index.js";
 import { Tool } from "../../types/index.js";
 
-// Real Home Assistant API service
 class HomeAssistantClimateService {
   async getClimateDevices(): Promise<Record<string, unknown>[]> {
     try {
@@ -32,6 +30,8 @@ class HomeAssistantClimateService {
     }
   }
 
+  // Note: preserved a pre-existing quirk where this returns a JSON string typed as object —
+  // the test suite (and the previous unified tool) depended on this shape downstream.
   async getClimateDevice(entity_id: string): Promise<Record<string, unknown> | null> {
     try {
       const hass = await get_hass();
@@ -40,7 +40,7 @@ class HomeAssistantClimateService {
         entity_id: state.entity_id,
         state: state.state,
         attributes: state.attributes,
-      });
+      }) as unknown as Record<string, unknown>;
     } catch (error) {
       logger.error(`Failed to get climate device ${entity_id} from HA:`, error);
       return null;
@@ -50,10 +50,7 @@ class HomeAssistantClimateService {
   async setHvacMode(entity_id: string, hvac_mode: string): Promise<boolean> {
     try {
       const hass = await get_hass();
-      await hass.callService("climate", "set_hvac_mode", {
-        entity_id,
-        hvac_mode,
-      });
+      await hass.callService("climate", "set_hvac_mode", { entity_id, hvac_mode });
       return true;
     } catch (error) {
       logger.error(`Failed to set HVAC mode for ${entity_id}:`, error);
@@ -70,14 +67,12 @@ class HomeAssistantClimateService {
     try {
       const hass = await get_hass();
       const serviceData: Record<string, unknown> = { entity_id };
-
       if (target_temp_high !== undefined && target_temp_low !== undefined) {
         serviceData.target_temp_high = target_temp_high;
         serviceData.target_temp_low = target_temp_low;
       } else if (temperature !== undefined) {
         serviceData.temperature = temperature;
       }
-
       await hass.callService("climate", "set_temperature", serviceData);
       return true;
     } catch (error) {
@@ -89,10 +84,7 @@ class HomeAssistantClimateService {
   async setFanMode(entity_id: string, fan_mode: string): Promise<boolean> {
     try {
       const hass = await get_hass();
-      await hass.callService("climate", "set_fan_mode", {
-        entity_id,
-        fan_mode,
-      });
+      await hass.callService("climate", "set_fan_mode", { entity_id, fan_mode });
       return true;
     } catch (error) {
       logger.error(`Failed to set fan mode for ${entity_id}:`, error);
@@ -101,156 +93,116 @@ class HomeAssistantClimateService {
   }
 }
 
-// Singleton instance
 const haClimateService = new HomeAssistantClimateService();
 
-// Define the schema for our tool parameters using Zod
-const climateControlSchema = z.object({
-  action: z
-    .enum(["list", "get", "set_hvac_mode", "set_temperature", "set_fan_mode"])
-    .describe("The action to perform on the climate device"),
-  entity_id: z
-    .string()
-    .optional()
-    .describe("The entity ID of the climate device (required for get and set actions)"),
+const climateReadSchema = z.object({
+  action: z.enum(["list", "get"]).describe("Read action"),
+  entity_id: z.string().optional().describe("Climate entity_id (required for 'get')"),
+});
+
+const climateActivateSchema = z.object({
+  action: z.enum(["set_hvac_mode", "set_temperature", "set_fan_mode"]).describe("Action to perform"),
+  entity_id: z.string().describe("Climate entity_id"),
   hvac_mode: z
     .enum(["off", "heat", "cool", "auto", "dry", "fan_only"])
     .optional()
-    .describe("The HVAC mode to set (required for set_hvac_mode)"),
-  temperature: z
-    .number()
-    .optional()
-    .describe("The target temperature to set (use for single setpoint devices)"),
-  target_temp_high: z
-    .number()
-    .optional()
-    .describe("The maximum target temperature for range devices (use with target_temp_low)"),
-  target_temp_low: z
-    .number()
-    .optional()
-    .describe("The minimum target temperature for range devices (use with target_temp_high)"),
+    .describe("HVAC mode (for set_hvac_mode)"),
+  temperature: z.number().optional().describe("Target temperature (single setpoint devices)"),
+  target_temp_high: z.number().optional().describe("Max target temp (range devices)"),
+  target_temp_low: z.number().optional().describe("Min target temp (range devices)"),
   fan_mode: z
     .enum(["auto", "low", "medium", "high"])
     .optional()
-    .describe("The fan mode to set (required for set_fan_mode)"),
+    .describe("Fan mode (for set_fan_mode)"),
 });
 
-// Infer the type from the schema
-type ClimateControlParams = z.infer<typeof climateControlSchema>;
+type ClimateReadParams = z.infer<typeof climateReadSchema>;
+type ClimateActivateParams = z.infer<typeof climateActivateSchema>;
 
-// --- Shared Execution Logic ---
-async function executeClimateControlLogic(params: ClimateControlParams): Promise<string> {
+async function executeClimateRead(params: ClimateReadParams): Promise<string> {
+  if (params.action === "list") {
+    const devices = await haClimateService.getClimateDevices();
+    return JSON.stringify({ success: true, devices });
+  }
+  if (params.entity_id == null) {
+    throw new Error("entity_id is required for 'get' action");
+  }
+  const deviceDetails = await haClimateService.getClimateDevice(params.entity_id);
+  if (!deviceDetails) {
+    throw new Error(`Climate entity_id '${params.entity_id}' not found.`);
+  }
+  return JSON.stringify({ success: true, ...deviceDetails });
+}
+
+async function executeClimateActivate(params: ClimateActivateParams): Promise<string> {
   let success: boolean;
-  let deviceDetails: Record<string, unknown> | null;
-
   switch (params.action) {
-    case "list": {
-      const devices = await haClimateService.getClimateDevices();
-      return JSON.stringify({ success: true, devices });
-    }
-
-    case "get": {
-      if (params.entity_id == null) {
-        throw new Error("entity_id is required for 'get' action");
-      }
-      deviceDetails = await haClimateService.getClimateDevice(params.entity_id);
-      if (!deviceDetails) {
-        throw new Error(`Climate entity_id '${params.entity_id}' not found.`);
-      }
-      return JSON.stringify({ success: true, ...deviceDetails });
-    }
-
     case "set_hvac_mode": {
-      if (!params.entity_id) {
-        throw new Error("entity_id is required for 'set_hvac_mode' action");
-      }
-      if (!params.hvac_mode) {
-        throw new Error("hvac_mode is required for 'set_hvac_mode' action");
-      }
+      if (!params.hvac_mode) throw new Error("hvac_mode is required for 'set_hvac_mode'");
       success = await haClimateService.setHvacMode(params.entity_id, params.hvac_mode);
-      if (!success) {
-        throw new Error(
-          `Failed to set HVAC mode for '${params.entity_id}'. Entity not found or mode not supported?`,
-        );
-      }
-      deviceDetails = await haClimateService.getClimateDevice(params.entity_id);
-      return JSON.stringify({ success: true, state: deviceDetails });
+      if (!success) throw new Error(`Failed to set HVAC mode for '${params.entity_id}'.`);
+      break;
     }
-
     case "set_temperature": {
-      if (!params.entity_id) {
-        throw new Error("entity_id is required for 'set_temperature' action");
-      }
       if (
         params.temperature === undefined &&
         params.target_temp_high === undefined &&
         params.target_temp_low === undefined
       ) {
-        throw new Error(
-          "At least one temperature parameter (temperature, target_temp_high, target_temp_low) is required for 'set_temperature' action",
-        );
+        throw new Error("At least one of temperature/target_temp_high/target_temp_low is required");
       }
       if (
         (params.target_temp_high !== undefined && params.target_temp_low === undefined) ||
         (params.target_temp_high === undefined && params.target_temp_low !== undefined)
       ) {
-        throw new Error(
-          "Both target_temp_high and target_temp_low must be provided together for temperature range setting",
-        );
+        throw new Error("target_temp_high and target_temp_low must be provided together");
       }
-
       success = await haClimateService.setTemperature(
         params.entity_id,
         params.temperature,
         params.target_temp_high,
         params.target_temp_low,
       );
-      if (!success) {
-        throw new Error(
-          `Failed to set temperature for '${params.entity_id}'. Entity not found or temperature setting not supported?`,
-        );
-      }
-      deviceDetails = await haClimateService.getClimateDevice(params.entity_id);
-      return JSON.stringify({ success: true, state: deviceDetails });
+      if (!success) throw new Error(`Failed to set temperature for '${params.entity_id}'.`);
+      break;
     }
-
     case "set_fan_mode": {
-      if (!params.entity_id) {
-        throw new Error("entity_id is required for 'set_fan_mode' action");
-      }
-      if (!params.fan_mode) {
-        throw new Error("fan_mode is required for 'set_fan_mode' action");
-      }
+      if (!params.fan_mode) throw new Error("fan_mode is required for 'set_fan_mode'");
       success = await haClimateService.setFanMode(params.entity_id, params.fan_mode);
-      if (!success) {
-        throw new Error(
-          `Failed to set fan mode for '${params.entity_id}'. Entity not found or mode not supported?`,
-        );
-      }
-      deviceDetails = await haClimateService.getClimateDevice(params.entity_id);
-      return JSON.stringify({ success: true, state: deviceDetails });
+      if (!success) throw new Error(`Failed to set fan mode for '${params.entity_id}'.`);
+      break;
     }
-
-    default:
-      throw new Error(`Unknown action: ${String(params.action)}`);
   }
+  const deviceDetails = await haClimateService.getClimateDevice(params.entity_id);
+  return JSON.stringify({ success: true, state: deviceDetails });
 }
 
-// --- Tool Definition ---
-export const climateControlTool: Tool = {
-  name: "climate_control",
-  description: "Control climate devices (thermostats, AC) in Home Assistant",
+export const climateTool: Tool = {
+  name: "climate",
+  description: "List all climate devices (thermostats, AC) or get the state of a specific one.",
   annotations: {
-    title: "Climate Control",
-    description: "Manage thermostats and air conditioning - set temperature, modes, and fan speeds",
+    title: "Climate Inventory",
+    description: "Read-only access to climate entities",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  parameters: climateReadSchema,
+  execute: executeClimateRead,
+};
+
+export const climateActivateTool: Tool = {
+  name: "climate_activate",
+  description: "Set HVAC mode, target temperature, or fan mode on climate devices.",
+  annotations: {
+    title: "Climate Activate",
+    description: "Actuate climate devices",
     readOnlyHint: false,
     destructiveHint: false,
     idempotentHint: true,
     openWorldHint: true,
   },
-  parameters: climateControlSchema,
-
-  execute: executeClimateControlLogic,
+  parameters: climateActivateSchema,
+  execute: executeClimateActivate,
 };
-
-

--- a/src/tools/homeassistant/cover.tool.ts
+++ b/src/tools/homeassistant/cover.tool.ts
@@ -1,8 +1,9 @@
 /**
- * Cover Control Tool for Home Assistant
+ * Cover tools for Home Assistant
  *
- * This tool allows controlling covers (blinds, curtains, garage doors, etc.) in Home Assistant.
- * Supports open, close, stop, and position control.
+ * Split into:
+ * - `covers` (read-only): list, get
+ * - `covers_activate`: open/close/stop/toggle + position/tilt
  */
 
 import { z } from "zod";
@@ -10,7 +11,6 @@ import { logger } from "../../utils/logger.js";
 import { get_hass } from "../../hass/index.js";
 import { Tool } from "../../types/index.js";
 
-// Real Home Assistant API service
 class HomeAssistantCoverService {
   async getCovers(): Promise<Record<string, unknown>[]> {
     try {
@@ -51,8 +51,7 @@ class HomeAssistantCoverService {
   ): Promise<boolean> {
     try {
       const hass = await get_hass();
-      const serviceData = { entity_id, ...data };
-      await hass.callService("cover", service, serviceData);
+      await hass.callService("cover", service, { entity_id, ...data });
       return true;
     } catch (error) {
       logger.error(`Failed to call service ${service} on ${entity_id}:`, error);
@@ -61,15 +60,16 @@ class HomeAssistantCoverService {
   }
 }
 
-// Singleton instance
 const haCoverService = new HomeAssistantCoverService();
 
-// Define the schema for our tool parameters using Zod
-const coverControlSchema = z.object({
+const coversReadSchema = z.object({
+  action: z.enum(["list", "get"]).describe("Read action"),
+  entity_id: z.string().optional().describe("Cover entity_id (required for 'get')"),
+});
+
+const coversActivateSchema = z.object({
   action: z
     .enum([
-      "list",
-      "get",
       "open_cover",
       "close_cover",
       "stop_cover",
@@ -80,134 +80,81 @@ const coverControlSchema = z.object({
       "stop_cover_tilt",
       "set_cover_tilt_position",
     ])
-    .describe("The action to perform"),
-  entity_id: z
-    .string()
-    .optional()
-    .describe("The entity ID of the cover (required for most actions)"),
-  position: z
-    .number()
-    .min(0)
-    .max(100)
-    .optional()
-    .describe("Position between 0 (closed) and 100 (open) for set_cover_position"),
+    .describe("Activation action"),
+  entity_id: z.string().describe("Cover entity_id"),
+  position: z.number().min(0).max(100).optional().describe("Position 0-100 (set_cover_position)"),
   tilt_position: z
     .number()
     .min(0)
     .max(100)
     .optional()
-    .describe("Tilt position between 0 and 100 for set_cover_tilt_position"),
+    .describe("Tilt position 0-100 (set_cover_tilt_position)"),
 });
 
-type CoverControlInput = z.infer<typeof coverControlSchema>;
+type CoversReadParams = z.infer<typeof coversReadSchema>;
+type CoversActivateParams = z.infer<typeof coversActivateSchema>;
 
-// Main tool execution function
-async function execute(params: CoverControlInput): Promise<string> {
+async function executeCoversRead(params: CoversReadParams): Promise<string> {
+  if (params.action === "list") {
+    const covers = await haCoverService.getCovers();
+    return JSON.stringify({ success: true, covers, count: covers.length }, null, 2);
+  }
+  if (!params.entity_id) {
+    return JSON.stringify({ success: false, error: "entity_id is required for get action" });
+  }
+  const cover = await haCoverService.getCover(params.entity_id);
+  if (!cover) {
+    return JSON.stringify({ success: false, error: `Cover ${params.entity_id} not found` });
+  }
+  return JSON.stringify({ success: true, cover }, null, 2);
+}
+
+async function executeCoversActivate(params: CoversActivateParams): Promise<string> {
   const { action, entity_id, position, tilt_position } = params;
-
   try {
-    switch (action) {
-      case "list": {
-        const covers = await haCoverService.getCovers();
-        return JSON.stringify(
-          {
-            success: true,
-            covers: covers,
-            count: covers.length,
-          },
-          null,
-          2,
-        );
-      }
-
-      case "get": {
-        if (!entity_id) {
-          return JSON.stringify({ success: false, error: "entity_id is required for get action" });
-        }
-        const cover = await haCoverService.getCover(entity_id);
-        if (!cover) {
-          return JSON.stringify({ success: false, error: `Cover ${entity_id} not found` });
-        }
-        return JSON.stringify({ success: true, cover: cover }, null, 2);
-      }
-
-      case "open_cover":
-      case "close_cover":
-      case "stop_cover":
-      case "toggle":
-      case "open_cover_tilt":
-      case "close_cover_tilt":
-      case "stop_cover_tilt": {
-        if (!entity_id) {
-          return JSON.stringify({
-            success: false,
-            error: `entity_id is required for ${action} action`,
-          });
-        }
-        const success = await haCoverService.callService(action, entity_id);
+    if (action === "set_cover_position") {
+      if (position === undefined) {
         return JSON.stringify({
-          success,
-          message: success
-            ? `Successfully executed ${action} on ${entity_id}`
-            : `Failed to execute ${action} on ${entity_id}`,
+          success: false,
+          error: "position is required for set_cover_position action",
         });
       }
-
-      case "set_cover_position": {
-        if (!entity_id) {
-          return JSON.stringify({
-            success: false,
-            error: "entity_id is required for set_cover_position action",
-          });
-        }
-        if (position === undefined) {
-          return JSON.stringify({
-            success: false,
-            error: "position is required for set_cover_position action",
-          });
-        }
-        const success = await haCoverService.callService("set_cover_position", entity_id, {
-          position,
-        });
-        return JSON.stringify({
-          success,
-          message: success
-            ? `Successfully set cover position to ${position}% on ${entity_id}`
-            : `Failed to set cover position on ${entity_id}`,
-        });
-      }
-
-      case "set_cover_tilt_position": {
-        if (!entity_id) {
-          return JSON.stringify({
-            success: false,
-            error: "entity_id is required for set_cover_tilt_position action",
-          });
-        }
-        if (tilt_position === undefined) {
-          return JSON.stringify({
-            success: false,
-            error: "tilt_position is required for set_cover_tilt_position action",
-          });
-        }
-        const success = await haCoverService.callService("set_cover_tilt_position", entity_id, {
-          tilt_position,
-        });
-        return JSON.stringify({
-          success,
-          message: success
-            ? `Successfully set cover tilt position to ${tilt_position}% on ${entity_id}`
-            : `Failed to set cover tilt position on ${entity_id}`,
-        });
-      }
-
-      default:
-        // `action` narrows to never after the exhaustive switch; cast to
-        // string for the runtime-fallback message.
-        return JSON.stringify({ success: false, error: `Unknown action: ${String(action)}` });
+      const success = await haCoverService.callService("set_cover_position", entity_id, {
+        position,
+      });
+      return JSON.stringify({
+        success,
+        message: success
+          ? `Successfully set cover position to ${position}% on ${entity_id}`
+          : `Failed to set cover position on ${entity_id}`,
+      });
     }
+    if (action === "set_cover_tilt_position") {
+      if (tilt_position === undefined) {
+        return JSON.stringify({
+          success: false,
+          error: "tilt_position is required for set_cover_tilt_position action",
+        });
+      }
+      const success = await haCoverService.callService("set_cover_tilt_position", entity_id, {
+        tilt_position,
+      });
+      return JSON.stringify({
+        success,
+        message: success
+          ? `Successfully set cover tilt position to ${tilt_position}% on ${entity_id}`
+          : `Failed to set cover tilt position on ${entity_id}`,
+      });
+    }
+    const success = await haCoverService.callService(action, entity_id);
+    return JSON.stringify({
+      success,
+      message: success
+        ? `Successfully executed ${action} on ${entity_id}`
+        : `Failed to execute ${action} on ${entity_id}`,
+    });
   } catch (error) {
-    logger.error("Error in cover control tool:", error);
+    logger.error("Error in cover activate tool:", error);
     return JSON.stringify({
       success: false,
       error: error instanceof Error ? error.message : "Unknown error occurred",
@@ -215,19 +162,32 @@ async function execute(params: CoverControlInput): Promise<string> {
   }
 }
 
-// Export the tool object
-export const coverControlTool: Tool = {
-  name: "cover_control",
-  description:
-    "Control covers (blinds, curtains, garage doors, shades, etc.) in Home Assistant. Supports opening, closing, stopping, toggling, and position control. Actions include: list (get all covers), get (get specific cover info), open_cover, close_cover, stop_cover, toggle, set_cover_position, and tilt controls for venetian blinds.",
+export const coversTool: Tool = {
+  name: "covers",
+  description: "List all covers (blinds, curtains, garage doors, shades) or get the state of one.",
   annotations: {
-    title: "Cover Control",
-    description: "Manage covers like blinds and garage doors - open, close, stop, and set positions",
+    title: "Covers Inventory",
+    description: "Read-only access to cover entities",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  parameters: coversReadSchema,
+  execute: executeCoversRead,
+};
+
+export const coversActivateTool: Tool = {
+  name: "covers_activate",
+  description: "Open, close, stop, toggle, or set the position/tilt of a cover.",
+  annotations: {
+    title: "Covers Activate",
+    description: "Actuate covers (blinds, curtains, garage doors)",
     readOnlyHint: false,
     destructiveHint: false,
     idempotentHint: true,
     openWorldHint: true,
   },
-  parameters: coverControlSchema,
-  execute,
+  parameters: coversActivateSchema,
+  execute: executeCoversActivate,
 };

--- a/src/tools/homeassistant/fan.tool.ts
+++ b/src/tools/homeassistant/fan.tool.ts
@@ -1,8 +1,9 @@
 /**
- * Fan Control Tool for Home Assistant
+ * Fan tools for Home Assistant
  *
- * This tool allows controlling fans in Home Assistant.
- * Supports turning on/off, speed control, direction, and oscillation.
+ * Split into:
+ * - `fans` (read-only): list, get
+ * - `fans_activate`: turn_on/off/toggle, set_percentage, set_preset_mode, oscillate, set_direction
  */
 
 import { z } from "zod";
@@ -10,7 +11,6 @@ import { logger } from "../../utils/logger.js";
 import { get_hass } from "../../hass/index.js";
 import { Tool } from "../../types/index.js";
 
-// Real Home Assistant API service
 class HomeAssistantFanService {
   async getFans(): Promise<Record<string, unknown>[]> {
     try {
@@ -51,8 +51,7 @@ class HomeAssistantFanService {
   ): Promise<boolean> {
     try {
       const hass = await get_hass();
-      const serviceData = { entity_id, ...data };
-      await hass.callService("fan", service, serviceData);
+      await hass.callService("fan", service, { entity_id, ...data });
       return true;
     } catch (error) {
       logger.error(`Failed to call service ${service} on ${entity_id}:`, error);
@@ -61,15 +60,16 @@ class HomeAssistantFanService {
   }
 }
 
-// Singleton instance
 const haFanService = new HomeAssistantFanService();
 
-// Define the schema for our tool parameters using Zod
-const fanControlSchema = z.object({
+const fansReadSchema = z.object({
+  action: z.enum(["list", "get"]).describe("Read action"),
+  entity_id: z.string().optional().describe("Fan entity_id (required for 'get')"),
+});
+
+const fansActivateSchema = z.object({
   action: z
     .enum([
-      "list",
-      "get",
       "turn_on",
       "turn_off",
       "toggle",
@@ -78,66 +78,39 @@ const fanControlSchema = z.object({
       "oscillate",
       "set_direction",
     ])
-    .describe("The action to perform"),
-  entity_id: z.string().optional().describe("The entity ID of the fan (required for most actions)"),
-  percentage: z
-    .number()
-    .min(0)
-    .max(100)
-    .optional()
-    .describe("Speed percentage between 0 and 100 (for set_percentage)"),
-  preset_mode: z
-    .string()
-    .optional()
-    .describe("Preset mode name like 'auto', 'smart', 'eco' (for set_preset_mode)"),
-  oscillating: z.boolean().optional().describe("Whether to oscillate (for oscillate action)"),
-  direction: z
-    .enum(["forward", "reverse"])
-    .optional()
-    .describe("Fan direction (for set_direction)"),
+    .describe("Activation action"),
+  entity_id: z.string().describe("Fan entity_id"),
+  percentage: z.number().min(0).max(100).optional().describe("Speed percentage 0-100"),
+  preset_mode: z.string().optional().describe("Preset mode like 'auto', 'smart', 'eco'"),
+  oscillating: z.boolean().optional().describe("Whether to oscillate"),
+  direction: z.enum(["forward", "reverse"]).optional().describe("Fan direction"),
 });
 
-type FanControlInput = z.infer<typeof fanControlSchema>;
+type FansReadParams = z.infer<typeof fansReadSchema>;
+type FansActivateParams = z.infer<typeof fansActivateSchema>;
 
-// Main tool execution function
-async function execute(params: FanControlInput): Promise<string> {
+async function executeFansRead(params: FansReadParams): Promise<string> {
+  if (params.action === "list") {
+    const fans = await haFanService.getFans();
+    return JSON.stringify({ success: true, fans, count: fans.length }, null, 2);
+  }
+  if (!params.entity_id) {
+    return JSON.stringify({ success: false, error: "entity_id is required for get action" });
+  }
+  const fan = await haFanService.getFan(params.entity_id);
+  if (!fan) {
+    return JSON.stringify({ success: false, error: `Fan ${params.entity_id} not found` });
+  }
+  return JSON.stringify({ success: true, fan }, null, 2);
+}
+
+async function executeFansActivate(params: FansActivateParams): Promise<string> {
   const { action, entity_id, percentage, preset_mode, oscillating, direction } = params;
-
   try {
     switch (action) {
-      case "list": {
-        const fans = await haFanService.getFans();
-        return JSON.stringify(
-          {
-            success: true,
-            fans: fans,
-            count: fans.length,
-          },
-          null,
-          2,
-        );
-      }
-
-      case "get": {
-        if (!entity_id) {
-          return JSON.stringify({ success: false, error: "entity_id is required for get action" });
-        }
-        const fan = await haFanService.getFan(entity_id);
-        if (!fan) {
-          return JSON.stringify({ success: false, error: `Fan ${entity_id} not found` });
-        }
-        return JSON.stringify({ success: true, fan: fan }, null, 2);
-      }
-
       case "turn_on":
       case "turn_off":
       case "toggle": {
-        if (!entity_id) {
-          return JSON.stringify({
-            success: false,
-            error: `entity_id is required for ${action} action`,
-          });
-        }
         const success = await haFanService.callService(action, entity_id);
         return JSON.stringify({
           success,
@@ -146,14 +119,7 @@ async function execute(params: FanControlInput): Promise<string> {
             : `Failed to execute ${action} on ${entity_id}`,
         });
       }
-
       case "set_percentage": {
-        if (!entity_id) {
-          return JSON.stringify({
-            success: false,
-            error: "entity_id is required for set_percentage action",
-          });
-        }
         if (percentage === undefined) {
           return JSON.stringify({
             success: false,
@@ -168,14 +134,7 @@ async function execute(params: FanControlInput): Promise<string> {
             : `Failed to set fan speed on ${entity_id}`,
         });
       }
-
       case "set_preset_mode": {
-        if (!entity_id) {
-          return JSON.stringify({
-            success: false,
-            error: "entity_id is required for set_preset_mode action",
-          });
-        }
         if (!preset_mode) {
           return JSON.stringify({
             success: false,
@@ -192,14 +151,7 @@ async function execute(params: FanControlInput): Promise<string> {
             : `Failed to set preset mode on ${entity_id}`,
         });
       }
-
       case "oscillate": {
-        if (!entity_id) {
-          return JSON.stringify({
-            success: false,
-            error: "entity_id is required for oscillate action",
-          });
-        }
         if (oscillating === undefined) {
           return JSON.stringify({
             success: false,
@@ -214,14 +166,7 @@ async function execute(params: FanControlInput): Promise<string> {
             : `Failed to set oscillation on ${entity_id}`,
         });
       }
-
       case "set_direction": {
-        if (!entity_id) {
-          return JSON.stringify({
-            success: false,
-            error: "entity_id is required for set_direction action",
-          });
-        }
         if (!direction) {
           return JSON.stringify({
             success: false,
@@ -236,14 +181,9 @@ async function execute(params: FanControlInput): Promise<string> {
             : `Failed to set fan direction on ${entity_id}`,
         });
       }
-
-      default:
-        // `action` narrows to never after the exhaustive switch; cast to
-        // string for the runtime-fallback message.
-        return JSON.stringify({ success: false, error: `Unknown action: ${String(action)}` });
     }
   } catch (error) {
-    logger.error("Error in fan control tool:", error);
+    logger.error("Error in fan activate tool:", error);
     return JSON.stringify({
       success: false,
       error: error instanceof Error ? error.message : "Unknown error occurred",
@@ -251,19 +191,33 @@ async function execute(params: FanControlInput): Promise<string> {
   }
 }
 
-// Export the tool object
-export const fanControlTool: Tool = {
-  name: "fan_control",
-  description:
-    "Control fans in Home Assistant. Supports turning on/off, speed control via percentage, preset modes, oscillation, and direction control. Actions include: list (get all fans), get (get specific fan info), turn_on, turn_off, toggle, set_percentage, set_preset_mode, oscillate, and set_direction.",
+export const fansTool: Tool = {
+  name: "fans",
+  description: "List all fans or get the state of a specific fan.",
   annotations: {
-    title: "Fan Control",
-    description: "Control fans - turn on/off, adjust speed, oscillation, and direction",
+    title: "Fans Inventory",
+    description: "Read-only access to fan entities",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  parameters: fansReadSchema,
+  execute: executeFansRead,
+};
+
+export const fansActivateTool: Tool = {
+  name: "fans_activate",
+  description:
+    "Control fans: turn on/off/toggle, set speed percentage, preset mode, oscillation, direction.",
+  annotations: {
+    title: "Fans Activate",
+    description: "Actuate fans",
     readOnlyHint: false,
     destructiveHint: false,
     idempotentHint: true,
     openWorldHint: true,
   },
-  parameters: fanControlSchema,
-  execute,
+  parameters: fansActivateSchema,
+  execute: executeFansActivate,
 };

--- a/src/tools/homeassistant/light-animation.tool.ts
+++ b/src/tools/homeassistant/light-animation.tool.ts
@@ -19,16 +19,18 @@ const LightAnimationParamsSchema = z.object({
 
 type LightAnimationParams = z.infer<typeof LightAnimationParamsSchema>;
 
-export const lightAnimationTool: Tool = {
-  name: "light_animation",
+export const lightAnimationActivateTool: Tool = {
+  name: "light_animation_activate",
   description:
     "Execute custom light animation sequences (e.g., police lights, alerts) on any RGB light.",
   parameters: LightAnimationParamsSchema,
   annotations: {
     title: "Light Animation",
     description: "Run custom animation sequences on lights",
+    readOnlyHint: false,
     destructiveHint: false,
     idempotentHint: false,
+    openWorldHint: true,
   },
   execute: async (params: LightAnimationParams) => {
     const { entity_id, sequence, loops } = params;

--- a/src/tools/homeassistant/light-scenario.tool.ts
+++ b/src/tools/homeassistant/light-scenario.tool.ts
@@ -19,15 +19,17 @@ const LightScenarioParamsSchema = z.object({
 
 type LightScenarioParams = z.infer<typeof LightScenarioParamsSchema>;
 
-export const lightScenarioTool: Tool = {
-    name: "light_scenario",
+export const lightScenarioActivateTool: Tool = {
+    name: "light_scenario_activate",
     description: "Apply ambient lighting moods (Chill, Nightly, Focus, etc.) to a specific area or light.",
     parameters: LightScenarioParamsSchema,
     annotations: {
         title: "Light Scenarios",
         description: "Set the mood of a room with one command",
+        readOnlyHint: false,
         destructiveHint: false,
         idempotentHint: true,
+        openWorldHint: true,
     },
     execute: async (params: LightScenarioParams) => {
         const { target, mood } = params;

--- a/src/tools/homeassistant/light-showcase.tool.ts
+++ b/src/tools/homeassistant/light-showcase.tool.ts
@@ -12,15 +12,17 @@ const LightShowcaseParamsSchema = z.object({
 
 type LightShowcaseParams = z.infer<typeof LightShowcaseParamsSchema>;
 
-export const lightShowcaseTool: Tool = {
-    name: "light_showcase",
+export const lightShowcaseActivateTool: Tool = {
+    name: "light_showcase_activate",
     description: "Run a choreographed light showcase that calls various moods and custom palettes to demonstrate system capabilities.",
     parameters: LightShowcaseParamsSchema,
     annotations: {
         title: "Light Showcase",
         description: "Demo mode: Cycles through Sunrise, Forest, Ocean, Romance, Cyberpunk, and Chill",
+        readOnlyHint: false,
         destructiveHint: false,
         idempotentHint: false,
+        openWorldHint: true,
     },
     execute: async (params: LightShowcaseParams) => {
         const { target, loops } = params;

--- a/src/tools/homeassistant/lights.tool.ts
+++ b/src/tools/homeassistant/lights.tool.ts
@@ -1,20 +1,18 @@
 /**
- * Lights Control Tool for Home Assistant (fastmcp format)
+ * Lights tools for Home Assistant
  *
- * This tool allows controlling lights in Home Assistant through the MCP.
- * It supports turning lights on/off, changing brightness, color, and color temperature.
+ * Split into:
+ * - `lights` (read-only): list, get
+ * - `lights_activate`: turn_on, turn_off (with brightness/color/etc.)
  */
 
 import { z } from "zod";
 import { UserError } from "fastmcp";
 import { logger } from "../../utils/logger.js";
-// Re-import BaseTool and MCPContext for the class definition
 
-import { MCPContext } from "../../mcp/types.js";
 import { get_hass } from "../../hass/index.js";
 import { Tool } from "../../types/index.js";
 
-// Real Home Assistant API service
 class HomeAssistantLightsService {
   async getLights(): Promise<Record<string, unknown>[]> {
     try {
@@ -72,115 +70,101 @@ class HomeAssistantLightsService {
   }
 }
 
-// Singleton instance
 const haLightsService = new HomeAssistantLightsService();
 
-// Define the schema for our tool parameters using Zod
-const lightsControlSchema = z.object({
-  action: z.enum(["list", "get", "turn_on", "turn_off"]).describe("The action to perform"),
-  entity_id: z
-    .string()
-    .optional()
-    .describe("The entity ID of the light to control (required for get, turn_on, turn_off)"),
-  brightness: z.number().min(0).max(255).optional().describe("Brightness level (0-255)"),
+const lightsReadSchema = z.object({
+  action: z.enum(["list", "get"]).describe("Read action to perform"),
+  entity_id: z.string().optional().describe("Light entity_id (required for 'get')"),
+});
+
+const lightsActivateSchema = z.object({
+  action: z.enum(["turn_on", "turn_off"]).describe("Activation action"),
+  entity_id: z.string().describe("Light entity_id"),
+  brightness: z.number().min(0).max(255).optional().describe("Brightness 0-255 (turn_on)"),
   color_temp: z
     .number()
     .min(153)
     .max(500)
     .optional()
-    .describe("Color temperature in Mireds (153-500)"),
+    .describe("Color temperature in Mireds (turn_on)"),
   rgb_color: z
     .array(z.number().min(0).max(255))
     .length(3)
     .optional()
-    .describe("RGB color as [r, g, b] (0-255 each)"),
-  effect: z
-    .string()
-    .optional()
-    .describe("Light effect (e.g., 'colorloop', 'random') - requires device support"),
-  transition: z.number().min(0).optional().describe("Transition time in seconds"),
+    .describe("RGB color [r,g,b] (turn_on)"),
+  effect: z.string().optional().describe("Light effect (turn_on)"),
+  transition: z.number().min(0).optional().describe("Transition seconds (turn_on)"),
 });
 
-// Infer the type from the schema
-type LightsControlParams = z.infer<typeof lightsControlSchema>;
+type LightsReadParams = z.infer<typeof lightsReadSchema>;
+type LightsActivateParams = z.infer<typeof lightsActivateSchema>;
 
-// Define the tool using the Tool interface
-export const lightsControlTool: Tool = {
-  name: "lights_control",
-  description:
-    "Control lights in Home Assistant. Supports listing all lights, getting state of a specific light, turning lights on with optional brightness/color settings, and turning lights off.",
-  parameters: lightsControlSchema,
-  execute: executeLightsControlLogic,
+async function executeLightsRead(params: LightsReadParams): Promise<string> {
+  if (params.action === "list") {
+    const lights = await haLightsService.getLights();
+    return JSON.stringify({ success: true, lights });
+  }
+  if (params.entity_id == null) {
+    throw new UserError("entity_id is required for 'get' action");
+  }
+  const lightDetails = await haLightsService.getLight(params.entity_id);
+  if (!lightDetails) {
+    throw new UserError(`Light entity_id '${params.entity_id}' not found.`);
+  }
+  return JSON.stringify({ success: true, ...lightDetails });
+}
+
+async function executeLightsActivate(params: LightsActivateParams): Promise<string> {
+  if (params.action === "turn_on") {
+    const attributes: Record<string, unknown> = {};
+    if (params.brightness !== undefined) attributes.brightness = params.brightness;
+    if (params.color_temp !== undefined) attributes.color_temp = params.color_temp;
+    if (params.rgb_color !== undefined) attributes.rgb_color = params.rgb_color;
+    if (params.effect !== undefined) attributes.effect = params.effect;
+    if (params.transition !== undefined) attributes.transition = params.transition;
+    const success = await haLightsService.turnOn(params.entity_id, attributes);
+    if (!success) {
+      throw new UserError(`Failed to turn on light '${params.entity_id}'.`);
+    }
+    const lightDetails = await haLightsService.getLight(params.entity_id);
+    return JSON.stringify({ success: true, state: lightDetails });
+  }
+
+  // turn_off
+  const success = await haLightsService.turnOff(params.entity_id);
+  if (!success) {
+    throw new UserError(`Failed to turn off light '${params.entity_id}'.`);
+  }
+  const lightDetails = await haLightsService.getLight(params.entity_id);
+  return JSON.stringify({ success: true, state: lightDetails });
+}
+
+export const lightsTool: Tool = {
+  name: "lights",
+  description: "List all lights or get the state of a specific light.",
   annotations: {
-    title: "Lights Control",
-    description: "Manage lighting in your home - turn on/off, adjust brightness, change colors",
+    title: "Lights Inventory",
+    description: "Read-only access to light entities",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  parameters: lightsReadSchema,
+  execute: executeLightsRead,
+};
+
+export const lightsActivateTool: Tool = {
+  name: "lights_activate",
+  description: "Turn lights on (with optional brightness/color/effect) or off.",
+  annotations: {
+    title: "Lights Activate",
+    description: "Actuate lights — turn on/off, set brightness and color",
     readOnlyHint: false,
     destructiveHint: false,
     idempotentHint: true,
     openWorldHint: true,
   },
+  parameters: lightsActivateSchema,
+  execute: executeLightsActivate,
 };
-
-// No need for the class wrapper anymore
-// export class LightsControlTool extends BaseTool { ... }
-
-// --- Shared Execution Logic ---
-// Extracted logic to be used by both fastmcp object and BaseTool class
-async function executeLightsControlLogic(params: LightsControlParams): Promise<string> {
-  let attributes: Record<string, unknown>;
-  let success: boolean;
-  let lightDetails: Record<string, unknown> | null;
-
-  switch (params.action) {
-    case "list": {
-      const lights = await haLightsService.getLights();
-      return JSON.stringify({ success: true, lights });
-    }
-
-    case "get": {
-      if (params.entity_id == null) {
-        throw new UserError("entity_id is required for 'get' action");
-      }
-      lightDetails = await haLightsService.getLight(params.entity_id);
-      if (!lightDetails) {
-        throw new UserError(`Light entity_id '${params.entity_id}' not found.`);
-      }
-      return JSON.stringify({ success: true, ...lightDetails });
-    }
-
-    case "turn_on": {
-      if (params.entity_id == null) {
-        throw new UserError("entity_id is required for 'turn_on' action");
-      }
-      attributes = {};
-      if (params.brightness !== undefined) attributes.brightness = params.brightness;
-      if (params.color_temp !== undefined) attributes.color_temp = params.color_temp;
-      if (params.rgb_color !== undefined) attributes.rgb_color = params.rgb_color;
-      if (params.effect !== undefined) attributes.effect = params.effect;
-      if (params.transition !== undefined) attributes.transition = params.transition;
-
-      success = await haLightsService.turnOn(params.entity_id, attributes);
-      if (!success) {
-        throw new UserError(`Failed to turn on light '${params.entity_id}'. Entity not found?`);
-      }
-      lightDetails = await haLightsService.getLight(params.entity_id); // Get updated state
-      return JSON.stringify({ success: true, state: lightDetails });
-    }
-
-    case "turn_off": {
-      if (params.entity_id == null) {
-        throw new UserError("entity_id is required for 'turn_off' action");
-      }
-      success = await haLightsService.turnOff(params.entity_id);
-      if (!success) {
-        throw new UserError(`Failed to turn off light '${params.entity_id}'. Entity not found?`);
-      }
-      lightDetails = await haLightsService.getLight(params.entity_id); // Get updated state
-      return JSON.stringify({ success: true, state: lightDetails });
-    }
-
-    default:
-      // Should be unreachable due to Zod validation
-      throw new UserError(`Unknown action: ${String(params.action)}`);
-  }
-}

--- a/src/tools/homeassistant/lock.tool.ts
+++ b/src/tools/homeassistant/lock.tool.ts
@@ -1,8 +1,9 @@
 /**
- * Lock Control Tool for Home Assistant
+ * Lock tools for Home Assistant
  *
- * This tool allows controlling locks in Home Assistant.
- * Supports locking, unlocking, and opening locks.
+ * Split into:
+ * - `locks` (read-only): list, get
+ * - `locks_activate`: lock, unlock, open  (destructive — unlocks physical doors)
  */
 
 import { z } from "zod";
@@ -10,7 +11,6 @@ import { logger } from "../../utils/logger.js";
 import { get_hass } from "../../hass/index.js";
 import { Tool } from "../../types/index.js";
 
-// Real Home Assistant API service
 class HomeAssistantLockService {
   async getLocks(): Promise<Record<string, unknown>[]> {
     try {
@@ -51,8 +51,7 @@ class HomeAssistantLockService {
   ): Promise<boolean> {
     try {
       const hass = await get_hass();
-      const serviceData = { entity_id, ...data };
-      await hass.callService("lock", service, serviceData);
+      await hass.callService("lock", service, { entity_id, ...data });
       return true;
     } catch (error) {
       logger.error(`Failed to call service ${service} on ${entity_id}:`, error);
@@ -61,77 +60,49 @@ class HomeAssistantLockService {
   }
 }
 
-// Singleton instance
 const haLockService = new HomeAssistantLockService();
 
-// Define the schema for our tool parameters using Zod
-const lockControlSchema = z.object({
-  action: z.enum(["list", "get", "lock", "unlock", "open"]).describe("The action to perform"),
-  entity_id: z
-    .string()
-    .optional()
-    .describe("The entity ID of the lock (required for most actions)"),
-  code: z.string().optional().describe("Optional code for locks that require a PIN/code"),
+const locksReadSchema = z.object({
+  action: z.enum(["list", "get"]).describe("Read action"),
+  entity_id: z.string().optional().describe("Lock entity_id (required for 'get')"),
 });
 
-type LockControlInput = z.infer<typeof lockControlSchema>;
+const locksActivateSchema = z.object({
+  action: z.enum(["lock", "unlock", "open"]).describe("Activation action"),
+  entity_id: z.string().describe("Lock entity_id"),
+  code: z.string().optional().describe("Optional PIN/code"),
+});
 
-// Main tool execution function
-async function execute(params: LockControlInput): Promise<string> {
-  const { action, entity_id, code } = params;
+type LocksReadParams = z.infer<typeof locksReadSchema>;
+type LocksActivateParams = z.infer<typeof locksActivateSchema>;
 
+async function executeLocksRead(params: LocksReadParams): Promise<string> {
+  if (params.action === "list") {
+    const locks = await haLockService.getLocks();
+    return JSON.stringify({ success: true, locks, count: locks.length }, null, 2);
+  }
+  if (!params.entity_id) {
+    return JSON.stringify({ success: false, error: "entity_id is required for get action" });
+  }
+  const lock = await haLockService.getLock(params.entity_id);
+  if (!lock) {
+    return JSON.stringify({ success: false, error: `Lock ${params.entity_id} not found` });
+  }
+  return JSON.stringify({ success: true, lock }, null, 2);
+}
+
+async function executeLocksActivate(params: LocksActivateParams): Promise<string> {
   try {
-    switch (action) {
-      case "list": {
-        const locks = await haLockService.getLocks();
-        return JSON.stringify(
-          {
-            success: true,
-            locks: locks,
-            count: locks.length,
-          },
-          null,
-          2,
-        );
-      }
-
-      case "get": {
-        if (!entity_id) {
-          return JSON.stringify({ success: false, error: "entity_id is required for get action" });
-        }
-        const lock = await haLockService.getLock(entity_id);
-        if (!lock) {
-          return JSON.stringify({ success: false, error: `Lock ${entity_id} not found` });
-        }
-        return JSON.stringify({ success: true, lock: lock }, null, 2);
-      }
-
-      case "lock":
-      case "unlock":
-      case "open": {
-        if (!entity_id) {
-          return JSON.stringify({
-            success: false,
-            error: `entity_id is required for ${action} action`,
-          });
-        }
-        const serviceData = code ? { code } : {};
-        const success = await haLockService.callService(action, entity_id, serviceData);
-        return JSON.stringify({
-          success,
-          message: success
-            ? `Successfully executed ${action} on ${entity_id}`
-            : `Failed to execute ${action} on ${entity_id}`,
-        });
-      }
-
-      default:
-        // `action` narrows to never after the exhaustive switch; cast to
-        // string for the runtime-fallback message.
-        return JSON.stringify({ success: false, error: `Unknown action: ${String(action)}` });
-    }
+    const serviceData = params.code ? { code: params.code } : {};
+    const success = await haLockService.callService(params.action, params.entity_id, serviceData);
+    return JSON.stringify({
+      success,
+      message: success
+        ? `Successfully executed ${params.action} on ${params.entity_id}`
+        : `Failed to execute ${params.action} on ${params.entity_id}`,
+    });
   } catch (error) {
-    logger.error("Error in lock control tool:", error);
+    logger.error("Error in lock activate tool:", error);
     return JSON.stringify({
       success: false,
       error: error instanceof Error ? error.message : "Unknown error occurred",
@@ -139,19 +110,33 @@ async function execute(params: LockControlInput): Promise<string> {
   }
 }
 
-// Export the tool object
-export const lockControlTool: Tool = {
-  name: "lock_control",
-  description:
-    "Control locks in Home Assistant. Supports locking, unlocking, and opening locks. Some locks may require a code/PIN. Actions include: list (get all locks), get (get specific lock info), lock, unlock, and open (for locks that support unlatching).",
+export const locksTool: Tool = {
+  name: "locks",
+  description: "List all locks or get the state of a specific lock.",
   annotations: {
-    title: "Lock Control",
-    description: "Manage smart locks - lock, unlock, and check status with optional security codes",
+    title: "Locks Inventory",
+    description: "Read-only access to lock entities",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  parameters: locksReadSchema,
+  execute: executeLocksRead,
+};
+
+export const locksActivateTool: Tool = {
+  name: "locks_activate",
+  description:
+    "Lock, unlock, or open (unlatch) physical locks. Unlocking is a security-sensitive operation.",
+  annotations: {
+    title: "Locks Activate",
+    description: "Actuate physical locks (security-sensitive)",
     readOnlyHint: false,
     destructiveHint: true,
     idempotentHint: true,
     openWorldHint: true,
   },
-  parameters: lockControlSchema,
-  execute,
+  parameters: locksActivateSchema,
+  execute: executeLocksActivate,
 };

--- a/src/tools/homeassistant/maintenance.tool.ts
+++ b/src/tools/homeassistant/maintenance.tool.ts
@@ -16,19 +16,21 @@ import { MCPContext } from "../../mcp/types.js";
 import { get_hass } from "../../hass/index.js";
 import { Tool } from "../../types/index.js";
 
-// Define the schema for maintenance tool parameters
+// Define the schema for maintenance tool parameters.
+// Read-only: all currently-implemented actions analyze state without modifying it.
+// `cleanup_orphaned_entities` (was a no-op stub) and `find_unused_automations` (was a
+// "not implemented" throw) were removed; resurrect them as a `maintenance_modify` tool
+// when they actually do something.
 const maintenanceSchema = z.object({
   action: z
     .enum([
       "find_orphaned_devices",
       "analyze_light_usage",
       "analyze_energy_consumption",
-      "cleanup_orphaned_entities",
       "device_health_check",
-      "find_unused_automations",
       "find_unavailable_entities",
     ])
-    .describe("The maintenance action to perform"),
+    .describe("The maintenance analysis to perform"),
   days: z
     .number()
     .min(1)
@@ -36,11 +38,6 @@ const maintenanceSchema = z.object({
     .optional()
     .default(30)
     .describe("Number of days to analyze for usage patterns"),
-  cleanup: z
-    .boolean()
-    .optional()
-    .default(false)
-    .describe("Actually perform cleanup (default: false, only report)"),
   entity_filter: z
     .string()
     .optional()
@@ -495,51 +492,24 @@ async function executeMaintenanceLogic(params: MaintenanceParams): Promise<strin
       );
     }
 
-    case "cleanup_orphaned_entities": {
-      if (!params.cleanup) {
-        throw new UserError(
-          "Cleanup not enabled. Set 'cleanup: true' to actually remove entities. " +
-            "Run 'find_orphaned_devices' first to see what would be removed.",
-        );
-      }
-      // For now, just return what would be cleaned up
-      const orphaned = await maintenanceService.findOrphanedDevices();
-      return JSON.stringify(
-        {
-          action: params.action,
-          warning:
-            "Automatic cleanup not yet implemented. Please remove entities manually through Home Assistant UI.",
-          entities_to_remove: orphaned,
-        },
-        null,
-        2,
-      );
-    }
-
-    case "find_unused_automations": {
-      throw new UserError(
-        "Finding unused automations requires automation history analysis. This feature is planned for a future update.",
-      );
-    }
-
     default:
       // params.action narrows to never after the exhaustive switch.
-      throw new UserError(`Unknown action: ${String(params.action)}`);
+      throw new UserError(`Unknown action: ${String((params as { action: string }).action)}`);
   }
 }
 
-// Export the tool
+// Export the tool — all currently-implemented actions are read-only analyses.
 export const maintenanceTool: Tool = {
   name: "maintenance",
   description:
-    "Perform maintenance tasks: find orphaned devices, analyze light usage and energy consumption, device health checks",
+    "Analyze Home Assistant health: find orphaned/unavailable devices, analyze light usage and energy consumption, run device health checks. All actions are read-only — no entities are removed or modified.",
   annotations: {
     title: "System Maintenance",
-    description: "Monitor and maintain Home Assistant system health - identify issues, unused devices, and optimization opportunities",
-    readOnlyHint: false,
-    destructiveHint: true,
+    description: "Read-only analysis of system health and optimization opportunities",
+    readOnlyHint: true,
+    destructiveHint: false,
     idempotentHint: true,
-    openWorldHint: false,
+    openWorldHint: true,
   },
   parameters: maintenanceSchema,
   execute: executeMaintenanceLogic,

--- a/src/tools/homeassistant/media-player.tool.ts
+++ b/src/tools/homeassistant/media-player.tool.ts
@@ -1,8 +1,9 @@
 /**
- * Media Player Control Tool for Home Assistant
+ * Media Player tools for Home Assistant
  *
- * This tool allows controlling media players in Home Assistant.
- * Supports play, pause, volume control, source selection, and media search.
+ * Split into:
+ * - `media_players` (read-only): list, get
+ * - `media_players_activate`: turn_on/off, toggle, playback control, volume, source, sound mode, play media
  */
 
 import { z } from "zod";
@@ -10,7 +11,6 @@ import { logger } from "../../utils/logger.js";
 import { get_hass } from "../../hass/index.js";
 import { Tool } from "../../types/index.js";
 
-// Real Home Assistant API service
 class HomeAssistantMediaPlayerService {
   async getMediaPlayers(): Promise<Record<string, unknown>[]> {
     try {
@@ -51,8 +51,7 @@ class HomeAssistantMediaPlayerService {
   ): Promise<boolean> {
     try {
       const hass = await get_hass();
-      const serviceData = { entity_id, ...data };
-      await hass.callService("media_player", service, serviceData);
+      await hass.callService("media_player", service, { entity_id, ...data });
       return true;
     } catch (error) {
       logger.error(`Failed to call service ${service} on ${entity_id}:`, error);
@@ -61,15 +60,16 @@ class HomeAssistantMediaPlayerService {
   }
 }
 
-// Singleton instance
 const haMediaPlayerService = new HomeAssistantMediaPlayerService();
 
-// Define the schema for our tool parameters using Zod
-const mediaPlayerControlSchema = z.object({
+const mediaPlayersReadSchema = z.object({
+  action: z.enum(["list", "get"]).describe("Read action"),
+  entity_id: z.string().optional().describe("Media player entity_id (required for 'get')"),
+});
+
+const mediaPlayersActivateSchema = z.object({
   action: z
     .enum([
-      "list",
-      "get",
       "turn_on",
       "turn_off",
       "toggle",
@@ -86,31 +86,45 @@ const mediaPlayerControlSchema = z.object({
       "select_source",
       "select_sound_mode",
     ])
-    .describe("The action to perform"),
-  entity_id: z
-    .string()
-    .optional()
-    .describe("The entity ID of the media player (required for most actions)"),
-  volume_level: z
-    .number()
-    .min(0)
-    .max(1)
-    .optional()
-    .describe("Volume level between 0 and 1 (for volume_set)"),
-  is_volume_muted: z.boolean().optional().describe("Mute state (for volume_mute)"),
-  media_content_id: z.string().optional().describe("Media content ID or URL (for play_media)"),
+    .describe("Activation action"),
+  entity_id: z.string().describe("Media player entity_id"),
+  volume_level: z.number().min(0).max(1).optional().describe("Volume 0-1 (volume_set)"),
+  is_volume_muted: z.boolean().optional().describe("Mute state (volume_mute)"),
+  media_content_id: z.string().optional().describe("Media content ID/URL (play_media)"),
   media_content_type: z
     .string()
     .optional()
-    .describe("Media content type like 'music', 'video', 'playlist' (for play_media)"),
-  source: z.string().optional().describe("Input source name (for select_source)"),
-  sound_mode: z.string().optional().describe("Sound mode name (for select_sound_mode)"),
+    .describe("Media type: music/video/playlist (play_media)"),
+  source: z.string().optional().describe("Input source (select_source)"),
+  sound_mode: z.string().optional().describe("Sound mode (select_sound_mode)"),
 });
 
-type MediaPlayerControlInput = z.infer<typeof mediaPlayerControlSchema>;
+type MediaPlayersReadParams = z.infer<typeof mediaPlayersReadSchema>;
+type MediaPlayersActivateParams = z.infer<typeof mediaPlayersActivateSchema>;
 
-// Main tool execution function
-async function execute(params: MediaPlayerControlInput): Promise<string> {
+async function executeMediaPlayersRead(params: MediaPlayersReadParams): Promise<string> {
+  if (params.action === "list") {
+    const players = await haMediaPlayerService.getMediaPlayers();
+    return JSON.stringify(
+      { success: true, media_players: players, count: players.length },
+      null,
+      2,
+    );
+  }
+  if (!params.entity_id) {
+    return JSON.stringify({ success: false, error: "entity_id is required for get action" });
+  }
+  const player = await haMediaPlayerService.getMediaPlayer(params.entity_id);
+  if (!player) {
+    return JSON.stringify({
+      success: false,
+      error: `Media player ${params.entity_id} not found`,
+    });
+  }
+  return JSON.stringify({ success: true, media_player: player }, null, 2);
+}
+
+async function executeMediaPlayersActivate(params: MediaPlayersActivateParams): Promise<string> {
   const {
     action,
     entity_id,
@@ -124,30 +138,6 @@ async function execute(params: MediaPlayerControlInput): Promise<string> {
 
   try {
     switch (action) {
-      case "list": {
-        const players = await haMediaPlayerService.getMediaPlayers();
-        return JSON.stringify(
-          {
-            success: true,
-            media_players: players,
-            count: players.length,
-          },
-          null,
-          2,
-        );
-      }
-
-      case "get": {
-        if (!entity_id) {
-          return JSON.stringify({ success: false, error: "entity_id is required for get action" });
-        }
-        const player = await haMediaPlayerService.getMediaPlayer(entity_id);
-        if (!player) {
-          return JSON.stringify({ success: false, error: `Media player ${entity_id} not found` });
-        }
-        return JSON.stringify({ success: true, media_player: player }, null, 2);
-      }
-
       case "turn_on":
       case "turn_off":
       case "toggle":
@@ -158,12 +148,6 @@ async function execute(params: MediaPlayerControlInput): Promise<string> {
       case "media_previous_track":
       case "volume_up":
       case "volume_down": {
-        if (!entity_id) {
-          return JSON.stringify({
-            success: false,
-            error: `entity_id is required for ${action} action`,
-          });
-        }
         const success = await haMediaPlayerService.callService(action, entity_id);
         return JSON.stringify({
           success,
@@ -172,14 +156,7 @@ async function execute(params: MediaPlayerControlInput): Promise<string> {
             : `Failed to execute ${action} on ${entity_id}`,
         });
       }
-
       case "volume_set": {
-        if (!entity_id) {
-          return JSON.stringify({
-            success: false,
-            error: "entity_id is required for volume_set action",
-          });
-        }
         if (volume_level === undefined) {
           return JSON.stringify({
             success: false,
@@ -196,14 +173,7 @@ async function execute(params: MediaPlayerControlInput): Promise<string> {
             : `Failed to set volume on ${entity_id}`,
         });
       }
-
       case "volume_mute": {
-        if (!entity_id) {
-          return JSON.stringify({
-            success: false,
-            error: "entity_id is required for volume_mute action",
-          });
-        }
         if (is_volume_muted === undefined) {
           return JSON.stringify({
             success: false,
@@ -220,14 +190,7 @@ async function execute(params: MediaPlayerControlInput): Promise<string> {
             : `Failed to mute/unmute ${entity_id}`,
         });
       }
-
       case "play_media": {
-        if (!entity_id) {
-          return JSON.stringify({
-            success: false,
-            error: "entity_id is required for play_media action",
-          });
-        }
         if (!media_content_id || !media_content_type) {
           return JSON.stringify({
             success: false,
@@ -245,14 +208,7 @@ async function execute(params: MediaPlayerControlInput): Promise<string> {
             : `Failed to play media on ${entity_id}`,
         });
       }
-
       case "select_source": {
-        if (!entity_id) {
-          return JSON.stringify({
-            success: false,
-            error: "entity_id is required for select_source action",
-          });
-        }
         if (!source) {
           return JSON.stringify({
             success: false,
@@ -269,14 +225,7 @@ async function execute(params: MediaPlayerControlInput): Promise<string> {
             : `Failed to select source on ${entity_id}`,
         });
       }
-
       case "select_sound_mode": {
-        if (!entity_id) {
-          return JSON.stringify({
-            success: false,
-            error: "entity_id is required for select_sound_mode action",
-          });
-        }
         if (!sound_mode) {
           return JSON.stringify({
             success: false,
@@ -293,14 +242,9 @@ async function execute(params: MediaPlayerControlInput): Promise<string> {
             : `Failed to select sound mode on ${entity_id}`,
         });
       }
-
-      default:
-        // `action` narrows to never after the exhaustive switch; cast to
-        // string for the runtime-fallback message.
-        return JSON.stringify({ success: false, error: `Unknown action: ${String(action)}` });
     }
   } catch (error) {
-    logger.error("Error in media player control tool:", error);
+    logger.error("Error in media player activate tool:", error);
     return JSON.stringify({
       success: false,
       error: error instanceof Error ? error.message : "Unknown error occurred",
@@ -308,19 +252,33 @@ async function execute(params: MediaPlayerControlInput): Promise<string> {
   }
 }
 
-// Export the tool object
-export const mediaPlayerControlTool: Tool = {
-  name: "media_player_control",
-  description:
-    "Control media players in Home Assistant. Supports playback control, volume adjustment, source selection, and media playing. Actions include: list (get all media players), get (get specific player info), turn_on/turn_off/toggle, play/pause/stop, next/previous track, volume controls, source and sound mode selection.",
+export const mediaPlayersTool: Tool = {
+  name: "media_players",
+  description: "List all media players or get the state of a specific media player.",
   annotations: {
-    title: "Media Player Control",
-    description: "Control media playback - play, pause, volume, source selection on TVs and speakers",
-    readOnlyHint: false,
+    title: "Media Players Inventory",
+    description: "Read-only access to media player entities",
+    readOnlyHint: true,
     destructiveHint: false,
     idempotentHint: true,
     openWorldHint: true,
   },
-  parameters: mediaPlayerControlSchema,
-  execute,
+  parameters: mediaPlayersReadSchema,
+  execute: executeMediaPlayersRead,
+};
+
+export const mediaPlayersActivateTool: Tool = {
+  name: "media_players_activate",
+  description:
+    "Control media players: playback, volume, source/sound mode selection, play media on TVs and speakers.",
+  annotations: {
+    title: "Media Players Activate",
+    description: "Actuate media players (audio/video output)",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  parameters: mediaPlayersActivateSchema,
+  execute: executeMediaPlayersActivate,
 };

--- a/src/tools/homeassistant/notify.tool.ts
+++ b/src/tools/homeassistant/notify.tool.ts
@@ -58,8 +58,8 @@ async function executeNotifyLogic(params: NotifyParams): Promise<string> {
 }
 
 // Tool object export (for FastMCP)
-export const notifyTool: Tool = {
-  name: "notify",
+export const notifyActivateTool: Tool = {
+  name: "notify_activate",
   description: "Send notifications through Home Assistant",
   annotations: {
     title: "Notify",

--- a/src/tools/homeassistant/scene.tool.ts
+++ b/src/tools/homeassistant/scene.tool.ts
@@ -1,66 +1,48 @@
 /**
- * Scene Tool for Home Assistant
+ * Scene Tools for Home Assistant
  *
- * This tool manages Home Assistant scenes - list and activate.
+ * Split into:
+ * - `scene` (read-only): list
+ * - `scene_activate`: activate (calls scene.turn_on, real-world effects via lights/climate)
  */
 
 import { z } from "zod";
 import { logger } from "../../utils/logger.js";
 
-import { MCPContext } from "../../mcp/types.js";
 import { get_hass } from "../../hass/index.js";
 import { Tool } from "../../types/index.js";
 
-// Define the schema for our tool parameters
-const sceneSchema = z.object({
-  action: z.enum(["list", "activate"]).describe("Action to perform with scenes"),
-  scene_id: z.string().optional().describe("Scene ID to activate (required for activate action)"),
+const sceneReadSchema = z.object({
+  action: z.literal("list").describe("List configured scenes"),
 });
 
-// Infer the type from the schema
-type SceneParams = z.infer<typeof sceneSchema>;
+const sceneActivateSchema = z.object({
+  action: z.literal("activate").describe("Activate a scene"),
+  scene_id: z.string().describe("Scene entity ID to activate"),
+});
 
-// Shared execution logic
-async function executeSceneLogic(params: SceneParams): Promise<string> {
-  logger.debug(`Executing scene logic with params: ${JSON.stringify(params)}`);
+type SceneReadParams = z.infer<typeof sceneReadSchema>;
+type SceneActivateParams = z.infer<typeof sceneActivateSchema>;
 
+async function executeSceneRead(_params: SceneReadParams): Promise<string> {
   try {
     const hass = await get_hass();
+    const states = await hass.getStates();
+    const scenes = states
+      .filter((state) => state.entity_id.startsWith("scene."))
+      .map((scene) => ({
+        entity_id: scene.entity_id,
+        name: scene.attributes?.friendly_name || scene.entity_id.split(".")[1],
+        description: scene.attributes?.description,
+      }));
 
-    if (params.action === "list") {
-      const states = await hass.getStates();
-      const scenes = states
-        .filter((state) => state.entity_id.startsWith("scene."))
-        .map((scene) => ({
-          entity_id: scene.entity_id,
-          name: scene.attributes?.friendly_name || scene.entity_id.split(".")[1],
-          description: scene.attributes?.description,
-        }));
-
-      return JSON.stringify({
-        success: true,
-        scenes,
-        total_count: scenes.length,
-      });
-    } else if (params.action === "activate") {
-      if (!params.scene_id) {
-        throw new Error("Scene ID is required for activate action");
-      }
-
-      await hass.callService("scene", "turn_on", {
-        entity_id: params.scene_id,
-      });
-
-      return JSON.stringify({
-        success: true,
-        message: `Successfully activated scene ${params.scene_id}`,
-        scene_id: params.scene_id,
-      });
-    }
-
-    throw new Error("Invalid action specified");
+    return JSON.stringify({
+      success: true,
+      scenes,
+      total_count: scenes.length,
+    });
   } catch (error) {
-    logger.error(`Error in scene logic: ${error instanceof Error ? error.message : String(error)}`);
+    logger.error(`Error listing scenes: ${error instanceof Error ? error.message : String(error)}`);
     return JSON.stringify({
       success: false,
       message: error instanceof Error ? error.message : "Unknown error occurred",
@@ -68,20 +50,53 @@ async function executeSceneLogic(params: SceneParams): Promise<string> {
   }
 }
 
-// Tool object export (for FastMCP)
+async function executeSceneActivate(params: SceneActivateParams): Promise<string> {
+  try {
+    const hass = await get_hass();
+    await hass.callService("scene", "turn_on", { entity_id: params.scene_id });
+    return JSON.stringify({
+      success: true,
+      message: `Successfully activated scene ${params.scene_id}`,
+      scene_id: params.scene_id,
+    });
+  } catch (error) {
+    logger.error(
+      `Error activating scene: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return JSON.stringify({
+      success: false,
+      message: error instanceof Error ? error.message : "Unknown error occurred",
+    });
+  }
+}
+
 export const sceneTool: Tool = {
   name: "scene",
-  description: "Manage and activate Home Assistant scenes",
+  description: "List Home Assistant scenes.",
   annotations: {
-    title: "Scene Management",
-    description: "List and activate pre-configured Home Assistant scenes for quick environment setup",
+    title: "Scene Inventory",
+    description: "Read-only listing of configured scenes",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  parameters: sceneReadSchema,
+  execute: executeSceneRead,
+};
+
+export const sceneActivateTool: Tool = {
+  name: "scene_activate",
+  description:
+    "Activate a pre-configured Home Assistant scene (calls scene.turn_on, actuates the underlying devices).",
+  annotations: {
+    title: "Scene Activate",
+    description: "Activate a scene — actuates the devices it controls",
     readOnlyHint: false,
     destructiveHint: false,
     idempotentHint: true,
     openWorldHint: true,
   },
-  parameters: sceneSchema,
-  execute: executeSceneLogic,
+  parameters: sceneActivateSchema,
+  execute: executeSceneActivate,
 };
-
-

--- a/src/tools/homeassistant/smart-scenarios.tool.ts
+++ b/src/tools/homeassistant/smart-scenarios.tool.ts
@@ -13,35 +13,22 @@
 import { z } from "zod";
 import { UserError } from "fastmcp";
 import { logger } from "../../utils/logger.js";
-import { BaseTool } from "../../mcp/BaseTool.js";
-import { MCPContext } from "../../mcp/types.js";
 import { get_hass, call_service } from "../../hass/index.js";
 import { Tool } from "../../types/index.js";
 
-// Define the schema for smart scenarios
-const smartScenariosSchema = z.object({
+// Read-only detection actions
+const smartScenariosReadSchema = z.object({
   action: z
-    .enum([
-      "detect_scenarios",
-      "apply_nobody_home",
-      "apply_window_heating_check",
-      "apply_motion_lighting",
-      "apply_energy_saving",
-      "apply_night_mode",
-      "apply_arrival_home",
-      "detect_issues",
-      "create_automation",
-    ])
-    .describe("The smart scenario action to perform"),
+    .enum(["detect_scenarios", "detect_issues"])
+    .describe("The detection action to perform"),
+});
 
-  mode: z
-    .enum(["detect", "apply", "auto"])
-    .optional()
-    .default("detect")
-    .describe("detect=only report, apply=execute actions, auto=create automation"),
-
+// Mutating apply actions (actuate devices, send notifications)
+const smartScenariosActivateSchema = z.object({
+  action: z
+    .enum(["apply_nobody_home", "apply_window_heating_check"])
+    .describe("The scenario to apply"),
   rooms: z.array(z.string()).optional().describe("Specific rooms/areas to apply scenario to"),
-
   temperature_reduction: z
     .number()
     .min(1)
@@ -49,15 +36,20 @@ const smartScenariosSchema = z.object({
     .optional()
     .default(3)
     .describe("Temperature reduction in degrees for climate control (default: 3)"),
-
   enable_notifications: z
     .boolean()
     .optional()
     .default(true)
-    .describe("Send notifications about scenario detection/actions"),
+    .describe("Send notifications about actions taken"),
+  mode: z
+    .enum(["detect", "apply", "auto"])
+    .optional()
+    .default("apply")
+    .describe("For apply_window_heating_check: 'apply' executes, 'detect' reports only"),
 });
 
-type SmartScenariosParams = z.infer<typeof smartScenariosSchema>;
+type SmartScenariosReadParams = z.infer<typeof smartScenariosReadSchema>;
+type SmartScenariosParams = z.infer<typeof smartScenariosActivateSchema>;
 
 interface ScenarioDetection {
   scenario_type: string;
@@ -541,12 +533,10 @@ class SmartScenariosService {
 // Singleton instance
 const smartScenariosService = new SmartScenariosService();
 
-// Execute smart scenarios logic
-async function executeSmartScenariosLogic(params: SmartScenariosParams): Promise<string> {
-  logger.debug(`Executing smart scenarios action: ${params.action}`);
-
-  switch (params.action) {
-    case "detect_scenarios": {
+async function executeSmartScenariosRead(params: SmartScenariosReadParams): Promise<string> {
+  logger.debug(`Executing smart scenarios read action: ${params.action}`);
+  try {
+    if (params.action === "detect_scenarios") {
       const nobodyHome = await smartScenariosService.detectNobodyHome();
       const windowConflicts = await smartScenariosService.detectWindowHeatingConflict();
       const energySaving = await smartScenariosService.detectEnergySavingOpportunities();
@@ -572,87 +562,71 @@ async function executeSmartScenariosLogic(params: SmartScenariosParams): Promise
       );
     }
 
-    case "apply_nobody_home": {
-      const result = await smartScenariosService.applyNobodyHomeScenario(params);
-      return JSON.stringify(result, null, 2);
-    }
-
-    case "apply_window_heating_check": {
-      const result = await smartScenariosService.applyWindowHeatingCheck(params);
-      return JSON.stringify(result, null, 2);
-    }
-
-    case "detect_issues": {
-      const windowConflicts = await smartScenariosService.detectWindowHeatingConflict();
-      const energySaving = await smartScenariosService.detectEnergySavingOpportunities();
-
-      return JSON.stringify(
-        {
-          action: params.action,
-          timestamp: new Date().toISOString(),
-          issues: [...windowConflicts, ...energySaving],
-          total_issues: windowConflicts.length + energySaving.length,
-        },
-        null,
-        2,
-      );
-    }
-
-    case "create_automation": {
-      throw new UserError(
-        "Automatic automation creation is not yet implemented. " +
-          "Use the 'detect_scenarios' action to get automation configs, " +
-          "then create them manually or use the automation_config tool.",
-      );
-    }
-
-    default:
-      throw new UserError(
-        `Action ${params.action} is not yet implemented. Available: detect_scenarios, apply_nobody_home, apply_window_heating_check, detect_issues`,
-      );
+    // detect_issues
+    const windowConflicts = await smartScenariosService.detectWindowHeatingConflict();
+    const energySaving = await smartScenariosService.detectEnergySavingOpportunities();
+    return JSON.stringify(
+      {
+        action: params.action,
+        timestamp: new Date().toISOString(),
+        issues: [...windowConflicts, ...energySaving],
+        total_issues: windowConflicts.length + energySaving.length,
+      },
+      null,
+      2,
+    );
+  } catch (error) {
+    logger.error(`smart_scenarios read failed: ${error}`);
+    throw new UserError(error instanceof Error ? error.message : String(error));
   }
 }
 
-// Export the tool
+async function executeSmartScenariosActivate(params: SmartScenariosParams): Promise<string> {
+  logger.debug(`Executing smart scenarios activate action: ${params.action}`);
+  try {
+    if (params.action === "apply_nobody_home") {
+      const result = await smartScenariosService.applyNobodyHomeScenario(params);
+      return JSON.stringify(result, null, 2);
+    }
+    if (params.action === "apply_window_heating_check") {
+      const result = await smartScenariosService.applyWindowHeatingCheck(params);
+      return JSON.stringify(result, null, 2);
+    }
+    throw new UserError(`Unknown apply action: ${(params as { action: string }).action}`);
+  } catch (error) {
+    logger.error(`smart_scenarios activate failed: ${error}`);
+    throw new UserError(error instanceof Error ? error.message : String(error));
+  }
+}
+
 export const smartScenariosTool: Tool = {
   name: "smart_scenarios",
   description:
-    "Detect and manage smart home scenarios: nobody home, window/heating conflicts, energy saving, and more",
+    "Detect common smart home scenarios (nobody home, window/heating conflicts, energy-saving opportunities). Read-only analysis.",
   annotations: {
-    title: "Smart Scenarios",
-    description: "Intelligent scenario detection and management for common smart home use cases",
+    title: "Smart Scenarios Detect",
+    description: "Detect smart home scenarios and energy issues",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  parameters: smartScenariosReadSchema,
+  execute: executeSmartScenariosRead,
+};
+
+export const smartScenariosActivateTool: Tool = {
+  name: "smart_scenarios_activate",
+  description:
+    "Apply smart home scenarios: turn off lights and adjust climate when nobody is home, or turn off heating when windows are open. Actuates devices and sends notifications.",
+  annotations: {
+    title: "Smart Scenarios Apply",
+    description: "Apply smart home scenarios (actuates devices, sends notifications)",
     readOnlyHint: false,
     destructiveHint: false,
     idempotentHint: true,
     openWorldHint: true,
   },
-  parameters: smartScenariosSchema,
-  execute: executeSmartScenariosLogic,
+  parameters: smartScenariosActivateSchema,
+  execute: executeSmartScenariosActivate,
 };
-
-// Export class for compatibility
-export class SmartScenariosTool extends BaseTool {
-  constructor() {
-    super({
-      name: smartScenariosTool.name,
-      description: smartScenariosTool.description,
-      parameters: smartScenariosSchema,
-      metadata: {
-        category: "automation",
-        version: "1.0.0",
-        tags: ["smart_home", "scenarios", "automation", "energy"],
-      },
-    });
-  }
-
-  public async execute(params: SmartScenariosParams, context: MCPContext): Promise<string> {
-    logger.debug(`Executing SmartScenariosTool with params: ${JSON.stringify(params)}`);
-    try {
-      const validatedParams = this.validateParams(params);
-      return await executeSmartScenariosLogic(validatedParams);
-    } catch (error) {
-      logger.error(`Error in SmartScenariosTool: ${String(error)}`);
-      throw error;
-    }
-  }
-}

--- a/src/tools/homeassistant/smart-scenarios.tool.ts
+++ b/src/tools/homeassistant/smart-scenarios.tool.ts
@@ -576,8 +576,9 @@ async function executeSmartScenariosRead(params: SmartScenariosReadParams): Prom
       2,
     );
   } catch (error) {
-    logger.error(`smart_scenarios read failed: ${error}`);
-    throw new UserError(error instanceof Error ? error.message : String(error));
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error(`smart_scenarios read failed: ${message}`);
+    throw new UserError(message);
   }
 }
 
@@ -594,8 +595,9 @@ async function executeSmartScenariosActivate(params: SmartScenariosParams): Prom
     }
     throw new UserError(`Unknown apply action: ${(params as { action: string }).action}`);
   } catch (error) {
-    logger.error(`smart_scenarios activate failed: ${error}`);
-    throw new UserError(error instanceof Error ? error.message : String(error));
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error(`smart_scenarios activate failed: ${message}`);
+    throw new UserError(message);
   }
 }
 

--- a/src/tools/homeassistant/switch.tool.ts
+++ b/src/tools/homeassistant/switch.tool.ts
@@ -1,19 +1,17 @@
 /**
- * Switch Control Tool for Home Assistant (fastmcp format)
+ * Switch tools for Home Assistant
  *
- * This tool allows controlling switches in Home Assistant through the MCP.
- * Supports on/off/toggle operations for any switch entity.
+ * Split into:
+ * - `switches` (read-only): list, get
+ * - `switches_activate`: turn_on, turn_off, toggle
  */
 
 import { z } from "zod";
 import { UserError } from "fastmcp";
 import { logger } from "../../utils/logger.js";
-import { BaseTool } from "../../mcp/BaseTool.js";
-import { MCPContext } from "../../mcp/types.js";
 import { get_hass } from "../../hass/index.js";
 import { Tool } from "../../types/index.js";
 
-// Home Assistant API service for switches
 class HomeAssistantSwitchService {
   async getSwitches(): Promise<Record<string, unknown>[]> {
     try {
@@ -48,160 +46,83 @@ class HomeAssistantSwitchService {
     }
   }
 
-  async turnOn(entity_id: string): Promise<boolean> {
+  async callService(service: "turn_on" | "turn_off" | "toggle", entity_id: string): Promise<boolean> {
     try {
       const hass = await get_hass();
-      await hass.callService("switch", "turn_on", { entity_id });
+      await hass.callService("switch", service, { entity_id });
       return true;
     } catch (error) {
-      logger.error(`Failed to turn on switch ${entity_id}:`, error);
-      return false;
-    }
-  }
-
-  async turnOff(entity_id: string): Promise<boolean> {
-    try {
-      const hass = await get_hass();
-      await hass.callService("switch", "turn_off", { entity_id });
-      return true;
-    } catch (error) {
-      logger.error(`Failed to turn off switch ${entity_id}:`, error);
-      return false;
-    }
-  }
-
-  async toggle(entity_id: string): Promise<boolean> {
-    try {
-      const hass = await get_hass();
-      await hass.callService("switch", "toggle", { entity_id });
-      return true;
-    } catch (error) {
-      logger.error(`Failed to toggle switch ${entity_id}:`, error);
+      logger.error(`Failed to ${service} switch ${entity_id}:`, error);
       return false;
     }
   }
 }
 
-// Singleton instance
 const haSwitchService = new HomeAssistantSwitchService();
 
-// Define the schema for our tool parameters using Zod
-const switchControlSchema = z.object({
-  action: z
-    .enum(["list", "get", "turn_on", "turn_off", "toggle"])
-    .describe("The action to perform"),
-  entity_id: z
-    .string()
-    .optional()
-    .describe(
-      "The entity ID of the switch to control (required for get, turn_on, turn_off, toggle)",
-    ),
+const switchesReadSchema = z.object({
+  action: z.enum(["list", "get"]).describe("Read action"),
+  entity_id: z.string().optional().describe("Switch entity_id (required for 'get')"),
 });
 
-// Infer the type from the schema
-type SwitchControlParams = z.infer<typeof switchControlSchema>;
+const switchesActivateSchema = z.object({
+  action: z.enum(["turn_on", "turn_off", "toggle"]).describe("Activation action"),
+  entity_id: z.string().describe("Switch entity_id"),
+});
 
-// Shared execution logic
-async function executeSwitchControlLogic(params: SwitchControlParams): Promise<string> {
-  let success: boolean;
-  let switchDetails: Record<string, unknown> | null;
+type SwitchesReadParams = z.infer<typeof switchesReadSchema>;
+type SwitchesActivateParams = z.infer<typeof switchesActivateSchema>;
 
-  switch (params.action) {
-    case "list": {
-      const switches = await haSwitchService.getSwitches();
-      return JSON.stringify({
-        switches,
-        total_count: switches.length,
-      });
-    }
-
-    case "get": {
-      if (params.entity_id == null) {
-        throw new UserError("entity_id is required for 'get' action");
-      }
-      switchDetails = await haSwitchService.getSwitch(params.entity_id);
-      if (!switchDetails) {
-        throw new UserError(`Switch entity_id '${params.entity_id}' not found.`);
-      }
-      return JSON.stringify(switchDetails);
-    }
-
-    case "turn_on": {
-      if (params.entity_id == null) {
-        throw new UserError("entity_id is required for 'turn_on' action");
-      }
-      success = await haSwitchService.turnOn(params.entity_id);
-      if (!success) {
-        throw new UserError(`Failed to turn on switch '${params.entity_id}'.`);
-      }
-      switchDetails = await haSwitchService.getSwitch(params.entity_id);
-      return JSON.stringify({ status: "success", state: switchDetails });
-    }
-
-    case "turn_off": {
-      if (params.entity_id == null) {
-        throw new UserError("entity_id is required for 'turn_off' action");
-      }
-      success = await haSwitchService.turnOff(params.entity_id);
-      if (!success) {
-        throw new UserError(`Failed to turn off switch '${params.entity_id}'.`);
-      }
-      switchDetails = await haSwitchService.getSwitch(params.entity_id);
-      return JSON.stringify({ status: "success", state: switchDetails });
-    }
-
-    case "toggle": {
-      if (params.entity_id == null) {
-        throw new UserError("entity_id is required for 'toggle' action");
-      }
-      success = await haSwitchService.toggle(params.entity_id);
-      if (!success) {
-        throw new UserError(`Failed to toggle switch '${params.entity_id}'.`);
-      }
-      switchDetails = await haSwitchService.getSwitch(params.entity_id);
-      return JSON.stringify({ status: "success", state: switchDetails });
-    }
-
-    default:
-      throw new UserError(`Unknown action: ${String(params.action)}`);
+async function executeSwitchesRead(params: SwitchesReadParams): Promise<string> {
+  if (params.action === "list") {
+    const switches = await haSwitchService.getSwitches();
+    return JSON.stringify({ success: true, switches, total_count: switches.length });
   }
+  if (params.entity_id == null) {
+    throw new UserError("entity_id is required for 'get' action");
+  }
+  const switchDetails = await haSwitchService.getSwitch(params.entity_id);
+  if (!switchDetails) {
+    throw new UserError(`Switch entity_id '${params.entity_id}' not found.`);
+  }
+  return JSON.stringify({ success: true, ...switchDetails });
 }
 
-// Define the tool using the Tool interface
-export const switchControlTool: Tool = {
-  name: "switch_control",
-  description:
-    "Control switches in Home Assistant. Supports listing all switches, getting state of a specific switch, and turning switches on/off/toggle. Works with any switch.* entity including smart plugs, relays, and virtual switches.",
-  parameters: switchControlSchema,
-  execute: executeSwitchControlLogic,
+async function executeSwitchesActivate(params: SwitchesActivateParams): Promise<string> {
+  const success = await haSwitchService.callService(params.action, params.entity_id);
+  if (!success) {
+    throw new UserError(`Failed to ${params.action} switch '${params.entity_id}'.`);
+  }
+  const switchDetails = await haSwitchService.getSwitch(params.entity_id);
+  return JSON.stringify({ success: true, state: switchDetails });
+}
+
+export const switchesTool: Tool = {
+  name: "switches",
+  description: "List all switches or get the state of a specific switch (smart plugs, relays, virtual switches).",
   annotations: {
-    title: "Switch Control",
-    description: "Manage switches - turn on/off, toggle, get state",
-    readOnlyHint: false,
+    title: "Switches Inventory",
+    description: "Read-only access to switch entities",
+    readOnlyHint: true,
     destructiveHint: false,
     idempotentHint: true,
     openWorldHint: true,
   },
+  parameters: switchesReadSchema,
+  execute: executeSwitchesRead,
 };
 
-// BaseTool class for compatibility
-export class SwitchControlTool extends BaseTool {
-  constructor() {
-    super({
-      name: switchControlTool.name,
-      description: switchControlTool.description,
-      parameters: switchControlSchema,
-      metadata: {
-        category: "home_assistant",
-        version: "1.0.0",
-        tags: ["switch", "home_assistant", "control"],
-      },
-    });
-  }
-
-  public async execute(params: SwitchControlParams, _context: MCPContext): Promise<string> {
-    logger.debug(`Executing SwitchControlTool with params: ${JSON.stringify(params)}`);
-    const validatedParams = this.validateParams(params);
-    return await executeSwitchControlLogic(validatedParams);
-  }
-}
+export const switchesActivateTool: Tool = {
+  name: "switches_activate",
+  description: "Turn switches on, off, or toggle.",
+  annotations: {
+    title: "Switches Activate",
+    description: "Actuate switches (smart plugs, relays)",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  parameters: switchesActivateSchema,
+  execute: executeSwitchesActivate,
+};

--- a/src/tools/homeassistant/todo.tool.ts
+++ b/src/tools/homeassistant/todo.tool.ts
@@ -1,34 +1,35 @@
 /**
- * To-Do Control Tool for Home Assistant (fastmcp format)
+ * To-Do Control Tools for Home Assistant
  *
- * This tool allows managing to-do lists in Home Assistant.
- * Supports listing to-do lists, getting items, adding, updating, and removing items.
+ * Split into:
+ * - `todo` (read-only): list_lists, get_items
+ * - `todo_modify`: add_item, update_item, remove_item
+ *
+ * These manage HA-side todo data, not external services — `_modify` not `_activate`.
  */
 
 import { z } from "zod";
 import { UserError } from "fastmcp";
-import { logger } from "../../utils/logger.js";
-import { BaseTool } from "../../mcp/BaseTool.js";
-import { MCPContext } from "../../mcp/types.js";
 import { get_hass } from "../../hass/index.js";
 import { get_hass_ws } from "../../hass/websocket-manager.js";
 import { Tool } from "../../types/index.js";
 
-// Define the schema for our tool parameters using Zod
-const todoControlSchema = z.object({
-  action: z
-    .enum(["list_lists", "get_items", "add_item", "update_item", "remove_item"])
-    .describe("The action to perform"),
+const todoReadSchema = z.object({
+  action: z.enum(["list_lists", "get_items"]).describe("The read action to perform"),
   entity_id: z
     .string()
     .optional()
-    .describe(
-      "The entity ID of the to-do list (required for get_items, add_item, update_item, remove_item)",
-    ),
-  item: z
-    .string()
+    .describe("The entity ID of the to-do list (required for get_items)"),
+  status: z
+    .enum(["needs_action", "completed"])
     .optional()
-    .describe("The name of the to-do item (required for add_item, update_item, remove_item)"),
+    .describe("Status filter for get_items (default: both)"),
+});
+
+const todoModifySchema = z.object({
+  action: z.enum(["add_item", "update_item", "remove_item"]).describe("The modify action"),
+  entity_id: z.string().describe("The entity ID of the to-do list"),
+  item: z.string().describe("The name of the to-do item"),
   rename: z.string().optional().describe("New name for the item (optional for update_item)"),
   status: z
     .enum(["needs_action", "completed"])
@@ -48,138 +49,104 @@ const todoControlSchema = z.object({
     .describe("Description for the item (optional for add_item, update_item)"),
 });
 
-// Infer the type from the schema
-type TodoControlParams = z.infer<typeof todoControlSchema>;
+type TodoReadParams = z.infer<typeof todoReadSchema>;
+type TodoModifyParams = z.infer<typeof todoModifySchema>;
 
-// Shared execution logic
-async function executeTodoControlLogic(params: TodoControlParams): Promise<string> {
-  switch (params.action) {
-    case "list_lists": {
-      const hass = await get_hass();
-      const states = await hass.getStates();
-      const lists = states
-        .filter((state) => state.entity_id.startsWith("todo."))
-        .map((state) => ({
-          entity_id: state.entity_id,
-          state: state.state,
-          friendly_name: state.attributes?.friendly_name,
-          supported_features: state.attributes?.supported_features,
-        }));
-      return JSON.stringify({ lists, total_count: lists.length });
-    }
-
-    case "get_items": {
-      if (params.entity_id == null) {
-        throw new UserError("entity_id is required for 'get_items' action");
-      }
-
-      const wsClient = await get_hass_ws();
-      const response = await wsClient.callService(
-        "todo",
-        "get_items",
-        {
-          entity_id: params.entity_id,
-          status: params.status ? [params.status] : ["needs_action", "completed"],
-        },
-        true, // returnResponse
-      );
-
-      return JSON.stringify(response);
-    }
-
-    case "add_item": {
-      if (params.entity_id == null || params.item == null) {
-        throw new UserError("entity_id and item are required for 'add_item' action");
-      }
-
-      const wsClient = await get_hass_ws();
-      const serviceData: any = {
-        entity_id: params.entity_id,
-        item: params.item,
-      };
-
-      if (params.due_date) serviceData.due_date = params.due_date;
-      if (params.due_datetime) serviceData.due_datetime = params.due_datetime;
-      if (params.description) serviceData.description = params.description;
-
-      await wsClient.callService("todo", "add_item", serviceData);
-      return JSON.stringify({ status: "success", message: `Added item '${params.item}'` });
-    }
-
-    case "update_item": {
-      if (params.entity_id == null || params.item == null) {
-        throw new UserError("entity_id and item are required for 'update_item' action");
-      }
-
-      const wsClient = await get_hass_ws();
-      const serviceData: any = {
-        entity_id: params.entity_id,
-        item: params.item,
-      };
-
-      if (params.rename) serviceData.rename = params.rename;
-      if (params.status) serviceData.status = params.status;
-      if (params.due_date) serviceData.due_date = params.due_date;
-      if (params.due_datetime) serviceData.due_datetime = params.due_datetime;
-      if (params.description) serviceData.description = params.description;
-
-      await wsClient.callService("todo", "update_item", serviceData);
-      return JSON.stringify({ status: "success", message: `Updated item '${params.item}'` });
-    }
-
-    case "remove_item": {
-      if (params.entity_id == null || params.item == null) {
-        throw new UserError("entity_id and item are required for 'remove_item' action");
-      }
-
-      const wsClient = await get_hass_ws();
-      await wsClient.callService("todo", "remove_item", {
-        entity_id: params.entity_id,
-        item: [params.item],
-      });
-      return JSON.stringify({ status: "success", message: `Removed item '${params.item}'` });
-    }
-
-    default:
-      throw new UserError(`Unknown action: ${String(params.action)}`);
+async function executeTodoRead(params: TodoReadParams): Promise<string> {
+  if (params.action === "list_lists") {
+    const hass = await get_hass();
+    const states = await hass.getStates();
+    const lists = states
+      .filter((state) => state.entity_id.startsWith("todo."))
+      .map((state) => ({
+        entity_id: state.entity_id,
+        state: state.state,
+        friendly_name: state.attributes?.friendly_name,
+        supported_features: state.attributes?.supported_features,
+      }));
+    return JSON.stringify({ lists, total_count: lists.length });
   }
+
+  // get_items
+  if (params.entity_id == null) {
+    throw new UserError("entity_id is required for 'get_items' action");
+  }
+  const wsClient = await get_hass_ws();
+  const response = await wsClient.callService(
+    "todo",
+    "get_items",
+    {
+      entity_id: params.entity_id,
+      status: params.status ? [params.status] : ["needs_action", "completed"],
+    },
+    true, // returnResponse
+  );
+  return JSON.stringify(response);
 }
 
-// Define the tool using the Tool interface
-export const todoControlTool: Tool = {
-  name: "todo_control",
-  description:
-    "Control and manage to-do lists in Home Assistant. Supports listing all to-do lists, getting items, and adding, updating, or removing items.",
-  parameters: todoControlSchema,
-  execute: executeTodoControlLogic,
+async function executeTodoModify(params: TodoModifyParams): Promise<string> {
+  const wsClient = await get_hass_ws();
+
+  if (params.action === "add_item") {
+    const serviceData: Record<string, unknown> = {
+      entity_id: params.entity_id,
+      item: params.item,
+    };
+    if (params.due_date) serviceData.due_date = params.due_date;
+    if (params.due_datetime) serviceData.due_datetime = params.due_datetime;
+    if (params.description) serviceData.description = params.description;
+    await wsClient.callService("todo", "add_item", serviceData);
+    return JSON.stringify({ status: "success", message: `Added item '${params.item}'` });
+  }
+
+  if (params.action === "update_item") {
+    const serviceData: Record<string, unknown> = {
+      entity_id: params.entity_id,
+      item: params.item,
+    };
+    if (params.rename) serviceData.rename = params.rename;
+    if (params.status) serviceData.status = params.status;
+    if (params.due_date) serviceData.due_date = params.due_date;
+    if (params.due_datetime) serviceData.due_datetime = params.due_datetime;
+    if (params.description) serviceData.description = params.description;
+    await wsClient.callService("todo", "update_item", serviceData);
+    return JSON.stringify({ status: "success", message: `Updated item '${params.item}'` });
+  }
+
+  // remove_item
+  await wsClient.callService("todo", "remove_item", {
+    entity_id: params.entity_id,
+    item: [params.item],
+  });
+  return JSON.stringify({ status: "success", message: `Removed item '${params.item}'` });
+}
+
+export const todoTool: Tool = {
+  name: "todo",
+  description: "List Home Assistant to-do lists or get items from a specific list.",
+  parameters: todoReadSchema,
+  execute: executeTodoRead,
   annotations: {
-    title: "To-Do Control",
-    description: "Manage to-do lists and items",
-    readOnlyHint: false,
+    title: "To-Do Inventory",
+    description: "Read-only access to to-do lists and items",
+    readOnlyHint: true,
     destructiveHint: false,
-    idempotentHint: false,
+    idempotentHint: true,
     openWorldHint: true,
   },
 };
 
-// BaseTool class for compatibility
-export class TodoControlTool extends BaseTool {
-  constructor() {
-    super({
-      name: todoControlTool.name,
-      description: todoControlTool.description,
-      parameters: todoControlSchema,
-      metadata: {
-        category: "home_assistant",
-        version: "1.0.0",
-        tags: ["todo", "list", "home_assistant", "control"],
-      },
-    });
-  }
-
-  public async execute(params: TodoControlParams, _context: MCPContext): Promise<string> {
-    logger.debug(`Executing TodoControlTool with params: ${JSON.stringify(params)}`);
-    const validatedParams = this.validateParams(params);
-    return await executeTodoControlLogic(validatedParams);
-  }
-}
+export const todoModifyTool: Tool = {
+  name: "todo_modify",
+  description: "Add, update, or remove items in a Home Assistant to-do list.",
+  parameters: todoModifySchema,
+  execute: executeTodoModify,
+  annotations: {
+    title: "To-Do Modify",
+    description: "Modify items in a to-do list (add, update, remove)",
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+};

--- a/src/tools/homeassistant/vacuum.tool.ts
+++ b/src/tools/homeassistant/vacuum.tool.ts
@@ -1,8 +1,9 @@
 /**
- * Vacuum Control Tool for Home Assistant
+ * Vacuum tools for Home Assistant
  *
- * This tool allows controlling robot vacuums in Home Assistant.
- * Supports start, stop, return to dock, and cleaning modes.
+ * Split into:
+ * - `vacuums` (read-only): list, get
+ * - `vacuums_activate`: start/pause/stop/return_to_base/clean_spot/locate, set_fan_speed, send_command
  */
 
 import { z } from "zod";
@@ -10,7 +11,6 @@ import { logger } from "../../utils/logger.js";
 import { get_hass } from "../../hass/index.js";
 import { Tool } from "../../types/index.js";
 
-// Real Home Assistant API service
 class HomeAssistantVacuumService {
   async getVacuums(): Promise<Record<string, unknown>[]> {
     try {
@@ -51,8 +51,7 @@ class HomeAssistantVacuumService {
   ): Promise<boolean> {
     try {
       const hass = await get_hass();
-      const serviceData = { entity_id, ...data };
-      await hass.callService("vacuum", service, serviceData);
+      await hass.callService("vacuum", service, { entity_id, ...data });
       return true;
     } catch (error) {
       logger.error(`Failed to call service ${service} on ${entity_id}:`, error);
@@ -61,15 +60,16 @@ class HomeAssistantVacuumService {
   }
 }
 
-// Singleton instance
 const haVacuumService = new HomeAssistantVacuumService();
 
-// Define the schema for our tool parameters using Zod
-const vacuumControlSchema = z.object({
+const vacuumsReadSchema = z.object({
+  action: z.enum(["list", "get"]).describe("Read action"),
+  entity_id: z.string().optional().describe("Vacuum entity_id (required for 'get')"),
+});
+
+const vacuumsActivateSchema = z.object({
   action: z
     .enum([
-      "list",
-      "get",
       "start",
       "pause",
       "stop",
@@ -79,123 +79,74 @@ const vacuumControlSchema = z.object({
       "set_fan_speed",
       "send_command",
     ])
-    .describe("The action to perform"),
-  entity_id: z
-    .string()
-    .optional()
-    .describe("The entity ID of the vacuum (required for most actions)"),
-  fan_speed: z.string().optional().describe("Fan speed/suction level name (for set_fan_speed)"),
-  command: z.string().optional().describe("Custom command to send (for send_command)"),
-  params: z.record(z.unknown()).optional().describe("Optional parameters for send_command"),
+    .describe("Activation action"),
+  entity_id: z.string().describe("Vacuum entity_id"),
+  fan_speed: z.string().optional().describe("Fan speed/suction level (set_fan_speed)"),
+  command: z.string().optional().describe("Vendor-specific command (send_command)"),
+  params: z.record(z.unknown()).optional().describe("Optional params for send_command"),
 });
 
-type VacuumControlInput = z.infer<typeof vacuumControlSchema>;
+type VacuumsReadParams = z.infer<typeof vacuumsReadSchema>;
+type VacuumsActivateParams = z.infer<typeof vacuumsActivateSchema>;
 
-// Main tool execution function
-async function execute(params: VacuumControlInput): Promise<string> {
+async function executeVacuumsRead(params: VacuumsReadParams): Promise<string> {
+  if (params.action === "list") {
+    const vacuums = await haVacuumService.getVacuums();
+    return JSON.stringify({ success: true, vacuums, count: vacuums.length }, null, 2);
+  }
+  if (!params.entity_id) {
+    return JSON.stringify({ success: false, error: "entity_id is required for get action" });
+  }
+  const vacuum = await haVacuumService.getVacuum(params.entity_id);
+  if (!vacuum) {
+    return JSON.stringify({ success: false, error: `Vacuum ${params.entity_id} not found` });
+  }
+  return JSON.stringify({ success: true, vacuum }, null, 2);
+}
+
+async function executeVacuumsActivate(params: VacuumsActivateParams): Promise<string> {
   const { action, entity_id, fan_speed, command, params: commandParams } = params;
-
   try {
-    switch (action) {
-      case "list": {
-        const vacuums = await haVacuumService.getVacuums();
-        return JSON.stringify(
-          {
-            success: true,
-            vacuums: vacuums,
-            count: vacuums.length,
-          },
-          null,
-          2,
-        );
-      }
-
-      case "get": {
-        if (!entity_id) {
-          return JSON.stringify({ success: false, error: "entity_id is required for get action" });
-        }
-        const vacuum = await haVacuumService.getVacuum(entity_id);
-        if (!vacuum) {
-          return JSON.stringify({ success: false, error: `Vacuum ${entity_id} not found` });
-        }
-        return JSON.stringify({ success: true, vacuum: vacuum }, null, 2);
-      }
-
-      case "start":
-      case "pause":
-      case "stop":
-      case "return_to_base":
-      case "clean_spot":
-      case "locate": {
-        if (!entity_id) {
-          return JSON.stringify({
-            success: false,
-            error: `entity_id is required for ${action} action`,
-          });
-        }
-        const success = await haVacuumService.callService(action, entity_id);
+    if (action === "set_fan_speed") {
+      if (!fan_speed) {
         return JSON.stringify({
-          success,
-          message: success
-            ? `Successfully executed ${action} on ${entity_id}`
-            : `Failed to execute ${action} on ${entity_id}`,
+          success: false,
+          error: "fan_speed is required for set_fan_speed action",
         });
       }
-
-      case "set_fan_speed": {
-        if (!entity_id) {
-          return JSON.stringify({
-            success: false,
-            error: "entity_id is required for set_fan_speed action",
-          });
-        }
-        if (!fan_speed) {
-          return JSON.stringify({
-            success: false,
-            error: "fan_speed is required for set_fan_speed action",
-          });
-        }
-        const success = await haVacuumService.callService("set_fan_speed", entity_id, {
-          fan_speed,
-        });
-        return JSON.stringify({
-          success,
-          message: success
-            ? `Successfully set fan speed to ${fan_speed} on ${entity_id}`
-            : `Failed to set fan speed on ${entity_id}`,
-        });
-      }
-
-      case "send_command": {
-        if (!entity_id) {
-          return JSON.stringify({
-            success: false,
-            error: "entity_id is required for send_command action",
-          });
-        }
-        if (!command) {
-          return JSON.stringify({
-            success: false,
-            error: "command is required for send_command action",
-          });
-        }
-        const serviceData = commandParams ? { command, params: commandParams } : { command };
-        const success = await haVacuumService.callService("send_command", entity_id, serviceData);
-        return JSON.stringify({
-          success,
-          message: success
-            ? `Successfully sent command ${command} to ${entity_id}`
-            : `Failed to send command to ${entity_id}`,
-        });
-      }
-
-      default:
-        // `action` narrows to never after the exhaustive switch; cast to
-        // string for the runtime-fallback message.
-        return JSON.stringify({ success: false, error: `Unknown action: ${String(action)}` });
+      const success = await haVacuumService.callService("set_fan_speed", entity_id, { fan_speed });
+      return JSON.stringify({
+        success,
+        message: success
+          ? `Successfully set fan speed to ${fan_speed} on ${entity_id}`
+          : `Failed to set fan speed on ${entity_id}`,
+      });
     }
+    if (action === "send_command") {
+      if (!command) {
+        return JSON.stringify({
+          success: false,
+          error: "command is required for send_command action",
+        });
+      }
+      const serviceData = commandParams ? { command, params: commandParams } : { command };
+      const success = await haVacuumService.callService("send_command", entity_id, serviceData);
+      return JSON.stringify({
+        success,
+        message: success
+          ? `Successfully sent command ${command} to ${entity_id}`
+          : `Failed to send command to ${entity_id}`,
+      });
+    }
+    const success = await haVacuumService.callService(action, entity_id);
+    return JSON.stringify({
+      success,
+      message: success
+        ? `Successfully executed ${action} on ${entity_id}`
+        : `Failed to execute ${action} on ${entity_id}`,
+    });
   } catch (error) {
-    logger.error("Error in vacuum control tool:", error);
+    logger.error("Error in vacuum activate tool:", error);
     return JSON.stringify({
       success: false,
       error: error instanceof Error ? error.message : "Unknown error occurred",
@@ -203,19 +154,33 @@ async function execute(params: VacuumControlInput): Promise<string> {
   }
 }
 
-// Export the tool object
-export const vacuumControlTool: Tool = {
-  name: "vacuum_control",
-  description:
-    "Control robot vacuums in Home Assistant. Supports starting, pausing, stopping, returning to dock, spot cleaning, locating the vacuum, fan speed control, and sending custom commands. Actions include: list (get all vacuums), get (get specific vacuum info), start, pause, stop, return_to_base, clean_spot, locate, set_fan_speed, and send_command for vendor-specific features.",
+export const vacuumsTool: Tool = {
+  name: "vacuums",
+  description: "List all robot vacuums or get the state of a specific vacuum.",
   annotations: {
-    title: "Vacuum Control",
-    description: "Control robot vacuums - start cleaning, pause, return to dock, and set fan speed",
-    readOnlyHint: false,
+    title: "Vacuums Inventory",
+    description: "Read-only access to vacuum entities",
+    readOnlyHint: true,
     destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  parameters: vacuumsReadSchema,
+  execute: executeVacuumsRead,
+};
+
+export const vacuumsActivateTool: Tool = {
+  name: "vacuums_activate",
+  description:
+    "Control robot vacuums: start/pause/stop, return to dock, spot cleaning, locate, fan speed, vendor-specific commands.",
+  annotations: {
+    title: "Vacuums Activate",
+    description: "Actuate robot vacuums (vendor send_command can do anything)",
+    readOnlyHint: false,
+    destructiveHint: true,
     idempotentHint: false,
     openWorldHint: true,
   },
-  parameters: vacuumControlSchema,
-  execute,
+  parameters: vacuumsActivateSchema,
+  execute: executeVacuumsActivate,
 };

--- a/src/tools/homeassistant/voice-command-ai-parser.tool.ts
+++ b/src/tools/homeassistant/voice-command-ai-parser.tool.ts
@@ -251,16 +251,16 @@ interface AIParseCommandResult {
 }
 
 // Export the tool object
-export const voiceCommandAIParserTool: Tool = {
-  name: "voice_command_ai_parser",
+export const voiceCommandAIParserActivateTool: Tool = {
+  name: "voice_command_ai_parser_activate",
   description:
-    "Parse voice commands using AI (Claude). Better understanding of natural language, context, and complex phrasing. Falls back gracefully if AI not available.",
+    "Parse voice commands using AI (Claude). Makes an outbound API call to api.anthropic.com (consumes API credits, sends transcript to a third party). Falls back gracefully if AI not available.",
   annotations: {
     title: "AI Voice Parser",
     description: "Use Claude AI for advanced natural language understanding of voice commands",
-    readOnlyHint: true,
+    readOnlyHint: false,
     destructiveHint: false,
-    idempotentHint: true,
+    idempotentHint: false,
     openWorldHint: true,
   },
   parameters: voiceCommandAIParserSchema,
@@ -275,8 +275,8 @@ export const voiceCommandAIParserTool: Tool = {
 export class VoiceCommandAIParserTool extends BaseTool {
   constructor() {
     super({
-      name: voiceCommandAIParserTool.name,
-      description: voiceCommandAIParserTool.description,
+      name: voiceCommandAIParserActivateTool.name,
+      description: voiceCommandAIParserActivateTool.description,
       parameters: voiceCommandAIParserSchema,
       metadata: {
         category: "speech",

--- a/src/tools/homeassistant/voice-command-executor.tool.ts
+++ b/src/tools/homeassistant/voice-command-executor.tool.ts
@@ -456,8 +456,8 @@ async function resolveAndExecute(
 }
 
 // Export the tool object
-export const voiceCommandExecutorTool: Tool = {
-  name: "voice_command_executor",
+export const voiceCommandExecutorActivateTool: Tool = {
+  name: "voice_command_executor_activate",
   description:
     "Execute parsed voice commands through Home Assistant. Maps intents to service calls and controls devices.",
   annotations: {
@@ -480,8 +480,8 @@ export const voiceCommandExecutorTool: Tool = {
 export class VoiceCommandExecutorTool extends BaseTool {
   constructor() {
     super({
-      name: voiceCommandExecutorTool.name,
-      description: voiceCommandExecutorTool.description,
+      name: voiceCommandExecutorActivateTool.name,
+      description: voiceCommandExecutorActivateTool.description,
       parameters: voiceCommandExecutorSchema,
       metadata: {
         category: "speech",

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,42 +1,52 @@
 import { Tool } from "../types/index";
-import { controlTool } from "./control.tool";
+import { controlActivateTool } from "./control.tool";
 import { historyTool } from "./history.tool";
-import { addonTool } from "./addon.tool";
-import { packageTool } from "./package.tool";
-import { automationConfigTool } from "./automation-config.tool";
+import { addonTool, addonModifyTool } from "./addon.tool";
+import { packageTool, packageModifyTool } from "./package.tool";
+import { automationConfigModifyTool } from "./automation-config.tool";
 import { subscribeEventsTool } from "./subscribe-events.tool";
 import { getSSEStatsTool } from "./sse-stats.tool";
 
-// Import Tool objects (not classes) from homeassistant directory
-import { lightsControlTool } from "./homeassistant/lights.tool";
-import { climateControlTool } from "./homeassistant/climate.tool";
-import { automationTool } from "./homeassistant/automation.tool";
+// Domain device tools — each split into <domain> (read-only) + <domain>_activate
+import { lightsTool, lightsActivateTool } from "./homeassistant/lights.tool";
+import { climateTool, climateActivateTool } from "./homeassistant/climate.tool";
+import {
+  automationTool,
+  automationModifyTool,
+  automationActivateTool,
+} from "./homeassistant/automation.tool";
 import { listDevicesTool } from "./homeassistant/list-devices.tool";
-import { notifyTool } from "./homeassistant/notify.tool";
-import { sceneTool } from "./homeassistant/scene.tool";
-import { mediaPlayerControlTool } from "./homeassistant/media-player.tool";
-import { coverControlTool } from "./homeassistant/cover.tool";
-import { lockControlTool } from "./homeassistant/lock.tool";
-import { fanControlTool } from "./homeassistant/fan.tool";
-import { vacuumControlTool } from "./homeassistant/vacuum.tool";
-import { alarmControlTool } from "./homeassistant/alarm.tool";
-import { switchControlTool } from "./homeassistant/switch.tool";
-import { todoControlTool } from "./homeassistant/todo.tool";
+import { notifyActivateTool } from "./homeassistant/notify.tool";
+import { sceneTool, sceneActivateTool } from "./homeassistant/scene.tool";
+import { mediaPlayersTool, mediaPlayersActivateTool } from "./homeassistant/media-player.tool";
+import { coversTool, coversActivateTool } from "./homeassistant/cover.tool";
+import { locksTool, locksActivateTool } from "./homeassistant/lock.tool";
+import { fansTool, fansActivateTool } from "./homeassistant/fan.tool";
+import { vacuumsTool, vacuumsActivateTool } from "./homeassistant/vacuum.tool";
+import { alarmsTool, alarmsActivateTool } from "./homeassistant/alarm.tool";
+import { switchesTool, switchesActivateTool } from "./homeassistant/switch.tool";
+import { todoTool, todoModifyTool } from "./homeassistant/todo.tool";
 import { maintenanceTool } from "./homeassistant/maintenance.tool";
-import { smartScenariosTool } from "./homeassistant/smart-scenarios.tool";
-import { lightAnimationTool } from "./homeassistant/light-animation.tool";
-import { lightScenarioTool } from "./homeassistant/light-scenario.tool";
-import { lightShowcaseTool } from "./homeassistant/light-showcase.tool";
-import { animationControlTool } from "./homeassistant/animation-control.tool";
-// Import voice tools
+import {
+  smartScenariosTool,
+  smartScenariosActivateTool,
+} from "./homeassistant/smart-scenarios.tool";
+import { lightAnimationActivateTool } from "./homeassistant/light-animation.tool";
+import { lightScenarioActivateTool } from "./homeassistant/light-scenario.tool";
+import { lightShowcaseActivateTool } from "./homeassistant/light-showcase.tool";
+import {
+  animationControlTool,
+  animationControlActivateTool,
+} from "./homeassistant/animation-control.tool";
+// Voice tools
 import { voiceCommandParserTool } from "./homeassistant/voice-command-parser.tool";
-import { voiceCommandExecutorTool } from "./homeassistant/voice-command-executor.tool";
-import { voiceCommandAIParserTool } from "./homeassistant/voice-command-ai-parser.tool";
+import { voiceCommandExecutorActivateTool } from "./homeassistant/voice-command-executor.tool";
+import { voiceCommandAIParserActivateTool } from "./homeassistant/voice-command-ai-parser.tool";
 import { traceTool } from "./homeassistant/trace.tool";
 import { entityStateTool } from "./entity-state.tool";
 import { searchEntitiesTool } from "./search-entities.tool";
 import { errorLogTool } from "./error-log.tool";
-import { dashboardTool } from "./dashboard.tool";
+import { dashboardTool, dashboardModifyTool } from "./dashboard.tool";
 import { renderTemplateTool } from "./template.tool";
 
 // Tool category types
@@ -63,52 +73,92 @@ interface _ToolMetadata {
   };
 }
 
-// Array to track all tools
+// Array to track all tools. Naming convention:
+//   - no suffix:  read-only (local HA queries or in-process)
+//   - _modify:    mutates HA config/state (no hardware actuation, no outbound messages)
+//   - _activate:  actuates hardware, sends messages, or makes remote (non-HA) API calls
 export const tools: Tool[] = [
-  controlTool,
+  // Universal control
+  controlActivateTool,
+
+  // History / events / SSE
   historyTool,
-  addonTool,
-  packageTool,
-  automationConfigTool,
   subscribeEventsTool,
   getSSEStatsTool,
-  // Home Assistant tools
-  lightsControlTool,
-  climateControlTool,
+
+  // Add-on / package management
+  addonTool,
+  addonModifyTool,
+  packageTool,
+  packageModifyTool,
+
+  // Automation
   automationTool,
+  automationModifyTool,
+  automationActivateTool,
+  automationConfigModifyTool,
+
+  // Generic entity / search / template / log
   listDevicesTool,
-  notifyTool,
+  entityStateTool,
+  searchEntitiesTool,
+  renderTemplateTool,
+  errorLogTool,
+
+  // Dashboard
+  dashboardTool,
+  dashboardModifyTool,
+
+  // Domain device tools (read-only + activate)
+  lightsTool,
+  lightsActivateTool,
+  climateTool,
+  climateActivateTool,
+  switchesTool,
+  switchesActivateTool,
+  coversTool,
+  coversActivateTool,
+  fansTool,
+  fansActivateTool,
+  locksTool,
+  locksActivateTool,
+  alarmsTool,
+  alarmsActivateTool,
+  mediaPlayersTool,
+  mediaPlayersActivateTool,
+  vacuumsTool,
+  vacuumsActivateTool,
+
+  // Scenes
   sceneTool,
-  mediaPlayerControlTool,
-  coverControlTool,
-  lockControlTool,
-  fanControlTool,
-  vacuumControlTool,
-  alarmControlTool,
-  switchControlTool,
-  todoControlTool,
+  sceneActivateTool,
+
+  // To-do lists
+  todoTool,
+  todoModifyTool,
+
+  // Notifications
+  notifyActivateTool,
+
+  // Maintenance / smart scenarios
   maintenanceTool,
   smartScenariosTool,
-  lightAnimationTool,
-  lightScenarioTool,
-  lightShowcaseTool,
+  smartScenariosActivateTool,
+
+  // Light animations / scenarios / showcase
+  lightAnimationActivateTool,
+  lightScenarioActivateTool,
+  lightShowcaseActivateTool,
   animationControlTool,
+  animationControlActivateTool,
+
   // Voice command tools
   voiceCommandParserTool,
-  voiceCommandExecutorTool,
-  voiceCommandAIParserTool,
-  // Trace tool (WebSocket-based)
+  voiceCommandExecutorActivateTool,
+  voiceCommandAIParserActivateTool,
+
+  // Trace
   traceTool,
-  // Generic entity state tool
-  entityStateTool,
-  // Powerful entity search
-  searchEntitiesTool,
-  // Error log
-  errorLogTool,
-  // Dashboard management
-  dashboardTool,
-  // Template evaluation
-  renderTemplateTool,
 ];
 
 // Function to get a tool by name
@@ -123,38 +173,55 @@ export function getAllTools(): Tool[] {
 
 // Export all tools individually
 export {
-  controlTool,
+  controlActivateTool,
   historyTool,
   addonTool,
+  addonModifyTool,
   packageTool,
-  automationConfigTool,
+  packageModifyTool,
+  automationConfigModifyTool,
   subscribeEventsTool,
   getSSEStatsTool,
   // Home Assistant tools
-  lightsControlTool,
-  climateControlTool,
+  lightsTool,
+  lightsActivateTool,
+  climateTool,
+  climateActivateTool,
   automationTool,
+  automationModifyTool,
+  automationActivateTool,
   listDevicesTool,
-  notifyTool,
+  notifyActivateTool,
   sceneTool,
-  mediaPlayerControlTool,
-  coverControlTool,
-  lockControlTool,
-  fanControlTool,
-  vacuumControlTool,
-  alarmControlTool,
-  switchControlTool,
-  todoControlTool,
+  sceneActivateTool,
+  mediaPlayersTool,
+  mediaPlayersActivateTool,
+  coversTool,
+  coversActivateTool,
+  locksTool,
+  locksActivateTool,
+  fansTool,
+  fansActivateTool,
+  vacuumsTool,
+  vacuumsActivateTool,
+  alarmsTool,
+  alarmsActivateTool,
+  switchesTool,
+  switchesActivateTool,
+  todoTool,
+  todoModifyTool,
   maintenanceTool,
   smartScenariosTool,
-  lightAnimationTool,
-  lightScenarioTool,
-  lightShowcaseTool,
+  smartScenariosActivateTool,
+  lightAnimationActivateTool,
+  lightScenarioActivateTool,
+  lightShowcaseActivateTool,
   animationControlTool,
+  animationControlActivateTool,
   // Voice command tools
   voiceCommandParserTool,
-  voiceCommandExecutorTool,
-  voiceCommandAIParserTool,
+  voiceCommandExecutorActivateTool,
+  voiceCommandAIParserActivateTool,
   // Trace tool
   traceTool,
   // Generic entity state
@@ -163,8 +230,9 @@ export {
   searchEntitiesTool,
   // Error log
   errorLogTool,
-  // Dashboard management
+  // Dashboard
   dashboardTool,
+  dashboardModifyTool,
   // Template evaluation
   renderTemplateTool,
 };

--- a/src/tools/package.tool.ts
+++ b/src/tools/package.tool.ts
@@ -1,98 +1,131 @@
 import { z } from "zod";
-import { Tool, PackageParams, HacsResponse } from "../types/index";
+import { Tool, HacsResponse } from "../types/index";
 import { APP_CONFIG } from "../config/app.config";
+
+const categoryEnum = z.enum([
+  "integration",
+  "plugin",
+  "theme",
+  "python_script",
+  "appdaemon",
+  "netdaemon",
+]);
+
+const packageReadSchema = z.object({
+  action: z.literal("list").describe("List installed/available packages"),
+  category: categoryEnum.describe("Package category"),
+});
+
+const packageModifySchema = z.object({
+  action: z.enum(["install", "uninstall", "update"]).describe("Lifecycle action"),
+  category: categoryEnum.describe("Package category"),
+  repository: z.string().optional().describe("Repository URL or name (required)"),
+  version: z.string().optional().describe("Version (only for install)"),
+});
+
+type PackageReadParams = z.infer<typeof packageReadSchema>;
+type PackageModifyParams = z.infer<typeof packageModifySchema>;
+
+const hacsBase = () => `${APP_CONFIG.HASS_HOST}/api/hacs`;
+
+async function executePackageRead(params: PackageReadParams) {
+  try {
+    const response = await fetch(`${hacsBase()}/repositories?category=${params.category}`, {
+      headers: {
+        Authorization: `Bearer ${APP_CONFIG.HASS_TOKEN}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch packages: ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as HacsResponse;
+    return { success: true, packages: data.repositories };
+  } catch (error) {
+    return {
+      success: false,
+      message: error instanceof Error ? error.message : "Unknown error occurred",
+    };
+  }
+}
+
+async function executePackageModify(params: PackageModifyParams) {
+  try {
+    if (!params.repository) {
+      throw new Error("Repository is required for this action");
+    }
+    let endpoint = "";
+    const body: Record<string, any> = {
+      category: params.category,
+      repository: params.repository,
+    };
+
+    switch (params.action) {
+      case "install":
+        endpoint = "/repository/install";
+        if (params.version) body.version = params.version;
+        break;
+      case "uninstall":
+        endpoint = "/repository/uninstall";
+        break;
+      case "update":
+        endpoint = "/repository/update";
+        break;
+    }
+
+    const response = await fetch(`${hacsBase()}${endpoint}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${APP_CONFIG.HASS_TOKEN}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to ${params.action} package: ${response.statusText}`);
+    }
+
+    return {
+      success: true,
+      message: `Successfully ${params.action}ed package ${params.repository}`,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      message: error instanceof Error ? error.message : "Unknown error occurred",
+    };
+  }
+}
 
 export const packageTool: Tool = {
   name: "package",
-  description: "Manage HACS packages and custom components - install, update, and manage community integrations",
+  description: "List HACS packages and custom components by category",
   annotations: {
-    title: "HACS Package Management",
-    description: "Install and manage Home Assistant community add-ons and custom components via HACS",
+    title: "HACS Package Inventory",
+    description: "Read-only view of HACS repositories",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  parameters: packageReadSchema,
+  execute: executePackageRead,
+};
+
+export const packageModifyTool: Tool = {
+  name: "package_modify",
+  description: "Install, uninstall, or update HACS packages",
+  annotations: {
+    title: "HACS Package Lifecycle",
+    description: "Modify HACS-managed integrations and custom components",
     readOnlyHint: false,
     destructiveHint: true,
     idempotentHint: false,
     openWorldHint: true,
   },
-  parameters: z.object({
-    action: z
-      .enum(["list", "install", "uninstall", "update"])
-      .describe("Action to perform with package"),
-    category: z
-      .enum(["integration", "plugin", "theme", "python_script", "appdaemon", "netdaemon"])
-      .describe("Package category"),
-    repository: z.string().optional().describe("Repository URL or name (required for install)"),
-    version: z.string().optional().describe("Version to install"),
-  }),
-  execute: async (params: PackageParams) => {
-    try {
-      const hacsBase = `${APP_CONFIG.HASS_HOST}/api/hacs`;
-
-      if (params.action === "list") {
-        const response = await fetch(`${hacsBase}/repositories?category=${params.category}`, {
-          headers: {
-            Authorization: `Bearer ${APP_CONFIG.HASS_TOKEN}`,
-            "Content-Type": "application/json",
-          },
-        });
-
-        if (!response.ok) {
-          throw new Error(`Failed to fetch packages: ${response.statusText}`);
-        }
-
-        const data = (await response.json()) as HacsResponse;
-        return {
-          success: true,
-          packages: data.repositories,
-        };
-      } else {
-        if (!params.repository) {
-          throw new Error("Repository is required for this action");
-        }
-
-        let endpoint = "";
-        const body: Record<string, any> = {
-          category: params.category,
-          repository: params.repository,
-        };
-
-        switch (params.action) {
-          case "install":
-            endpoint = "/repository/install";
-            if (params.version) {
-              body.version = params.version;
-            }
-            break;
-          case "uninstall":
-            endpoint = "/repository/uninstall";
-            break;
-          case "update":
-            endpoint = "/repository/update";
-            break;
-        }
-
-        const response = await fetch(`${hacsBase}${endpoint}`, {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${APP_CONFIG.HASS_TOKEN}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(body),
-        });
-
-        if (!response.ok) {
-          throw new Error(`Failed to ${params.action} package: ${response.statusText}`);
-        }
-
-        return {
-          success: true,
-          message: `Successfully ${params.action}ed package ${params.repository}`,
-        };
-      }
-    } catch (error) {
-      return {
-        success: false,
-        message: error instanceof Error ? error.message : "Unknown error occurred",
-      };
-    }
-  },
+  parameters: packageModifySchema,
+  execute: executePackageModify,
 };

--- a/src/tools/sse-stats.tool.ts
+++ b/src/tools/sse-stats.tool.ts
@@ -11,7 +11,7 @@ export const getSSEStatsTool: Tool = {
     description: "View metrics and diagnostics for active SSE connections and subscriptions",
     readOnlyHint: true,
     destructiveHint: false,
-    idempotentHint: true,
+    idempotentHint: false,
     openWorldHint: false,
   },
   parameters: z.object({

--- a/src/tools/subscribe-events.tool.ts
+++ b/src/tools/subscribe-events.tool.ts
@@ -11,8 +11,8 @@ export const subscribeEventsTool: Tool = {
     description: "Stream real-time Home Assistant events for entity state changes and system events",
     readOnlyHint: true,
     destructiveHint: false,
-    idempotentHint: true,
-    openWorldHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
   },
   parameters: z.object({
     token: z.string().describe("Authentication token (required)"),


### PR DESCRIPTION
# Pull Request

## 📝 Description

Refactors the tool surface so each tool's name signals its side-effect class. This makes it easy for clients (and humans reading the tool list) to tell at a glance whether calling a tool will read data, change Home Assistant state, or actuate hardware / send messages / hit a remote API.

**Naming convention**

- **no suffix** — read-only (local HA queries or pure in-process work)
- **`_modify`** — mutates HA config/state; no hardware actuation, no outbound messages
- **`_activate`** — actuates hardware, sends messages to people, or makes remote (non-HA) API calls

Tools with mixed actions are **split** so each new tool has one clear class. For example, `lights_control` (which had both `list`/`get` and `turn_on`/`turn_off`) becomes `lights` (read-only) and `lights_activate`.

Tool count grows from 32 → 54 (16 splits each adding a second half).

**Splits** — one read-only tool + one mutating sibling for each:

| Original | Read-only | Mutating |
|---|---|---|
| `lights_control` | `lights` | `lights_activate` |
| `climate_control` | `climate` | `climate_activate` |
| `switch_control` | `switches` | `switches_activate` |
| `cover_control` | `covers` | `covers_activate` |
| `fan_control` | `fans` | `fans_activate` |
| `lock_control` | `locks` | `locks_activate` |
| `alarm_control` | `alarms` | `alarms_activate` |
| `media_player_control` | `media_players` | `media_players_activate` |
| `vacuum_control` | `vacuums` | `vacuums_activate` |
| `addon` | `addon` | `addon_modify` |
| `package` | `package` | `package_modify` |
| `dashboard` | `dashboard` | `dashboard_modify` |
| `scene` | `scene` | `scene_activate` |
| `todo_control` | `todo` | `todo_modify` |
| `smart_scenarios` | `smart_scenarios` | `smart_scenarios_activate` |
| `animation_control` | `animation_control` | `animation_control_activate` |
| `automation` | `automation` | `automation_modify` (toggle) + `automation_activate` (trigger) |

**Pure renames** (single class — just gets the right suffix):

| Original | New |
|---|---|
| `control` | `control_activate` |
| `notify` | `notify_activate` |
| `automation_config` | `automation_config_modify` |
| `voice_command_executor` | `voice_command_executor_activate` |
| `voice_command_ai_parser` | `voice_command_ai_parser_activate` (also `readOnlyHint` was incorrectly `true` — this tool calls `api.anthropic.com`) |
| `light_animation` | `light_animation_activate` |
| `light_scenario` | `light_scenario_activate` |
| `light_showcase` | `light_showcase_activate` |

**Read-only tools** (no rename needed): `get_history`, `get_entity_state`, `search_entities`, `render_template`, `get_error_log`, `list_devices`, `trace`, `voice_command_parser`, `subscribe_events`, `get_sse_stats`, `maintenance`.

**Annotation hygiene** — `ToolAnnotations` flags (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) are realigned with actual behavior. A new self-test enforces the convention: a tool with `readOnlyHint: true` must have no suffix; any other tool must end in `_modify` or `_activate`.

**Cleanup** — dropped action enum values that were either no-op stubs or "not implemented" throws:

- `maintenance`: removed `cleanup_orphaned_entities` (stub) and `find_unused_automations` (threw). Remaining actions are all read-only analyses.
- `smart_scenarios`: removed `create_automation` (threw).

## 🔗 Related Issues

Fixes #

<!-- (No tracking issue — this is a maintainer-initiated refactor.) -->

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 💥 Breaking change (fix or feature that causes existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🎨 Code style/refactoring (no functional changes)
- [x] 🧪 Test updates
- [ ] ⚙️ Build/CI configuration
- [ ] 🔧 Other (please describe):

## 🧪 Testing

- [x] Tests pass locally (`bun test`) — **557 pass / 0 fail** across 48 files
- [x] Linter passes (`bun run lint`) — **0 errors**, 1516 warnings (down 72 from `main`'s 1588 — the rewritten tool files have cleaner code)
- [ ] Manual testing completed (recommend MCP smoke test against a live HA before merge — connect a client, run `tools/list`, verify the 54 new names appear, exercise one tool from each class)
- [x] Added new tests for new functionality

### Test Coverage

Three new tests:

1. **Suffix-convention self-test** in `__tests__/tools/all-tools.test.ts` — iterates every registered tool and asserts that `readOnlyHint: true` tools have no suffix and all others end in `_modify` or `_activate`. This locks the convention against regressions.
2. **Split-tool assertions** in `__tests__/tools/automation.test.ts` — verifies `automation` (list), `automation_modify` (toggle), `automation_activate` (trigger) each behave correctly.
3. **Split-tool assertions** in `__tests__/tools/scene-control.test.ts` — verifies `scene` (list) and `scene_activate` (activate).

Existing tool tests were updated to reference the new names. No tests were dropped.

## 📸 Screenshots (if applicable)

N/A

## ✅ Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have updated the CHANGELOG.md (if applicable)

## 📚 Documentation

- [ ] README.md updated
- [x] CHANGELOG.md updated (proposed `[1.5.0]` entry)
- [x] Documentation in docs/ updated (`docs/TOOLS_REFERENCE.md`, `docs/VOICE_COMMAND_EXECUTION.md`, `VOICE_COMMAND_QUICK_REF.md`)
- [x] JSDoc comments added/updated (split files carry a short header comment explaining the split)
- [ ] No documentation changes needed

## 🔍 Additional Context

- The REST `/control` route in `src/api/routes.ts` and `src/routes/tool.routes.ts` now resolves `control_activate` internally. The REST endpoint name (`/control`) is **unchanged** for backward compat — only the underlying MCP tool name changed.
- The legacy `MCP_SCHEMA` descriptor in `src/mcp/schema.ts` was already partially stale relative to the runtime tool list (e.g. `addon_management` vs `addon`, `scene_control` vs `scene`) and is now aligned with the new names.

## 📋 Breaking Changes

MCP clients that hardcode tool names will need to update to the new names. The mapping is the two tables in the Description above. The most common cases:

| If your client calls… | …call this instead |
|---|---|
| `control` | `control_activate` |
| `lights_control` with `turn_on`/`turn_off` | `lights_activate` |
| `lights_control` with `list`/`get` | `lights` |
| `notify` | `notify_activate` |
| `automation` with `trigger` | `automation_activate` |
| `automation` with `toggle` | `automation_modify` |
| `automation_config` | `automation_config_modify` |
| (same pattern for the other 14 split domains) | |

The REST `/control` and `/list_devices` endpoints are unchanged — only MCP tool names moved.

## 🎉 Benefits

- **Safer defaults for permissive clients.** A client that wants to auto-approve read-only tool calls can do so just from the tool name, without consulting `annotations`.
- **Clearer audit trails.** Logs and prompts that include tool names now self-describe their side-effect class.
- **Bug fixes folded in.** `voice_command_ai_parser`'s `readOnlyHint: true` was wrong — it calls Anthropic's API. The rename forces the correct annotation. Same for `addon`/`package`/`dashboard`/`maintenance` whose `destructiveHint` previously spanned read-only sub-actions.
- **Dead code removed.** Three unimplemented action enum values (`maintenance.cleanup_orphaned_entities`, `maintenance.find_unused_automations`, `smart_scenarios.create_automation`) are gone.